### PR TITLE
Handle non-200 requests

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -147,9 +147,11 @@ var getJobsCmd = &cobra.Command{
 
 		jobsResponses, err := client.GetJobs(daysBackLimit)
 		if err != nil {
-			// fmt.Printf("responses: %v\n", jobsResponses)
-			panic(err)
+			fmt.Printf("failed to get jobs: %v\n", err)
+			return
 		}
+
+		fmt.Printf("Total Jobs: %d\n", len(jobsResponses))
 
 		// Print the job IDs gathered from the response
 		for _, job := range jobsResponses {

--- a/lib/client.go
+++ b/lib/client.go
@@ -94,6 +94,11 @@ func (c *Client) GetJobs(daysBackLimit int) ([]JobsResponse, error) {
 			return nil, err
 		}
 
+		if httpResponse.StatusCode != 200 {
+			fmt.Printf("error getting jobs: %s\n", httpResponse.Status)
+			return nil, fmt.Errorf("error getting jobs: %s", httpResponse.Status)
+		}
+
 		defer httpResponse.Body.Close()
 
 		var jobs JobsResponse


### PR DESCRIPTION
Not sure why I wasn't doing this before, but the client was not handling when a response code was not 200.