### PR TITLE
Fix output to not break scripts

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -151,8 +151,6 @@ var getJobsCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Total Jobs: %d\n", len(jobsResponses))
-
 		// Print the job IDs gathered from the response
 		for _, job := range jobsResponses {
 			for _, j := range job.Jobs {


### PR DESCRIPTION
This printout was breaking the send-slack-msg.sh script here: https://github.com/redhat-best-practices-for-k8s/telco-bot/blob/main/scripts/send-slack-msg.sh#L11

`jq` was attempting to parse the entire file and it was encountering non-JSON text.