### PR TITLE
Use ubuntu-latest for linters

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Run Linters and Vet
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
 


### PR DESCRIPTION
To match the other workflows in go-quay and go-dci, lets switch this to use `ubuntu-latest`.