### PR TITLE
Add binaries to releases

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,74 @@
+name: Release binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist
+          BINARY_NAME=go-dci
+          OUTPUT="dist/${BINARY_NAME}"
+          go build -trimpath -ldflags "-s -w" -o "$OUTPUT" .
+
+      - name: Package
+        run: |
+          set -euo pipefail
+          BINARY_NAME=go-dci
+          TAG="${GITHUB_REF_NAME}"
+          PKG_NAME="${BINARY_NAME}_${TAG}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          mkdir -p dist/pkg
+          (cd dist && tar -czf "pkg/${PKG_NAME}.tar.gz" "${BINARY_NAME}")
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-dci_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: dist/pkg/*
+          if-no-files-found: error
+
+  upload:
+    name: Upload release assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Show downloaded files
+        run: ls -laR dist | cat
+
+      - name: Attach assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.tar.gz
+


### PR DESCRIPTION
Similar to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2208

This pull request introduces a new GitHub Actions workflow for building and releasing binaries upon published releases. The workflow automates the compilation, packaging, and attachment of release artifacts for multiple operating systems and architectures.

Release automation:

* Added `.github/workflows/release-binaries.yaml` to build Go binaries for `linux` and `darwin` platforms on both `amd64` and `arm64` architectures, triggered on release publication.
* Configured steps for code checkout, Go environment setup, binary compilation, packaging into tarballs, and artifact upload for each platform/architecture combination.
* Added a job to collect all build artifacts and attach them as assets to the GitHub release using `softprops/action-gh-release`.