### PR TITLE
chore: upgrade Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/go-dci
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
## Summary

Bump Go version from 1.26.1 to 1.26.2 in go.mod.

## Security Fixes

[Go 1.26.2 announcement](https://groups.google.com/g/golang-announce/c/EdhZqrQ98hk/m/41DopX_WAAAJ) — 10 CVEs fixed:

| CVE | Package | Issue |
|-----|---------|-------|
| CVE-2026-27140 | cmd/go | Code smuggling via crafted SWIG file names |
| CVE-2026-27143 | cmd/compile | Invalid arithmetic over loop induction variables |
| CVE-2026-27144 | cmd/compile | Incorrect pointer unwrapping in memory moves |
| CVE-2026-32280 | crypto/x509 | DoS via unlimited chain building with many intermediates |
| CVE-2026-32281 | crypto/x509 | DoS via inefficient policy mapping validation |
| CVE-2026-32282 | os (unix) | Symlink traversal in Root.Chmod on Linux |
| CVE-2026-32283 | crypto/tls | TLS 1.3 deadlock from multiple key update messages |
| CVE-2026-32288 | archive/tar | Unbounded memory allocation from sparse map entries |
| CVE-2026-32289 | html/template | XSS via incorrect escaping in JS template literals |
| CVE-2026-33810 | crypto/x509 | DNS constraint bypass with case-sensitive wildcards |

## Related PRs

- sebrandon1/bps-operator#67
- sebrandon1/compliance-operator-dashboard#77
- sebrandon1/go-enphase#14
- sebrandon1/go-quay#82
- sebrandon1/go-skylight#32
- sebrandon1/grab#40
- sebrandon1/imagecertinfo-operator#87
- sebrandon1/jiracrawler#77
- sebrandon1/mirrorbot#31
- sebrandon1/testapp#5
- sebrandon1/tls-compliance-operator#86
- sebrandon1/yaml-to-readme#127
- sebrandon1/ztp-dashboard#47

> skylight-bridge is already at Go 1.26.2.