### PR TITLE
fix: handle digest field as string or array from DCI API

### DIFF
--- a/lib/structs.go
+++ b/lib/structs.go
@@ -1,5 +1,34 @@
 package lib
 
+import "encoding/json"
+
+// StringOrSlice handles JSON fields that can be either a string or []string.
+type StringOrSlice []string
+
+func (s *StringOrSlice) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	if data[0] == '"' {
+		var single string
+		if err := json.Unmarshal(data, &single); err != nil {
+			return err
+		}
+
+		*s = []string{single}
+		return nil
+	}
+
+	var slice []string
+	if err := json.Unmarshal(data, &slice); err != nil {
+		return err
+	}
+
+	*s = slice
+	return nil
+}
+
 // Shared structs
 
 type Meta struct {
@@ -18,7 +47,7 @@ type Product struct {
 }
 
 type Data struct {
-	Digest      []string `json:"digest"`
+	Digest      StringOrSlice `json:"digest"`
 	DisplayName string   `json:"display_name"`
 	PullURL     string   `json:"pull_url"`
 	Tags        []string `json:"tags"`

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -1,0 +1,84 @@
+package lib
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStringOrSlice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected StringOrSlice
+	}{
+		{
+			name:     "single string",
+			input:    `{"digest":"sha256:abc123"}`,
+			expected: StringOrSlice{"sha256:abc123"},
+		},
+		{
+			name:     "empty string",
+			input:    `{"digest":""}`,
+			expected: StringOrSlice{""},
+		},
+		{
+			name:     "array of strings",
+			input:    `{"digest":["sha256:abc123","sha256:def456"]}`,
+			expected: StringOrSlice{"sha256:abc123", "sha256:def456"},
+		},
+		{
+			name:     "empty array",
+			input:    `{"digest":[]}`,
+			expected: StringOrSlice{},
+		},
+		{
+			name:     "null value",
+			input:    `{"digest":null}`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data Data
+			if err := json.Unmarshal([]byte(tt.input), &data); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(data.Digest) != len(tt.expected) {
+				t.Fatalf("expected %d elements, got %d", len(tt.expected), len(data.Digest))
+			}
+
+			for i, v := range tt.expected {
+				if data.Digest[i] != v {
+					t.Errorf("element %d: expected %q, got %q", i, v, data.Digest[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStringOrSlice_UnmarshalJSON_Error(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "number value",
+			input: `{"digest":42}`,
+		},
+		{
+			name:  "boolean value",
+			input: `{"digest":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data Data
+			if err := json.Unmarshal([]byte(tt.input), &data); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The DCI API sometimes returns `data.digest` as a plain string instead of `[]string`, causing `json: cannot unmarshal string into Go struct field Data.jobs.components.data.digest of type []string` errors
- Adds a `StringOrSlice` custom type with `UnmarshalJSON` that accepts both forms
- This fixes the `weekly-query` workflow failure in telco-bot: https://github.com/redhat-best-practices-for-k8s/telco-bot/actions/runs/25267013145/job/74083110119

## Test plan
- Added unit tests covering single string, array of strings, and empty array cases
- All existing tests continue to pass