### PR TITLE
refactor: add ResourceState type for DCI resource state fields

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -128,7 +128,7 @@ var updateComponentCmd = &cobra.Command{
 			updates.Name = updateComponentName
 		}
 		if updateComponentState != "" {
-			updates.State = updateComponentState
+			updates.State = lib.ResourceState(updateComponentState)
 		}
 		if updateComponentVersion != "" {
 			updates.Version = updateComponentVersion

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -112,7 +112,7 @@ var updateComponentTypeCmd = &cobra.Command{
 			updates.Name = updateComponentTypeName
 		}
 		if updateComponentTypeState != "" {
-			updates.State = updateComponentTypeState
+			updates.State = lib.ResourceState(updateComponentTypeState)
 		}
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -147,7 +147,7 @@ var updateRemoteCICmd = &cobra.Command{
 			updates.Name = updateRemoteCINameFlag
 		}
 		if updateRemoteCIStateFlag != "" {
-			updates.State = updateRemoteCIStateFlag
+			updates.State = lib.ResourceState(updateRemoteCIStateFlag)
 		}
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -142,7 +142,7 @@ var updateTeamCmd = &cobra.Command{
 			updates.Name = updateTeamNameFlag
 		}
 		if updateTeamStateFlag != "" {
-			updates.State = updateTeamStateFlag
+			updates.State = lib.ResourceState(updateTeamStateFlag)
 		}
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -172,7 +172,7 @@ var updateUserCmd = &cobra.Command{
 			updates.Fullname = updateUserFullnameFlag
 		}
 		if updateUserStateFlag != "" {
-			updates.State = updateUserStateFlag
+			updates.State = lib.ResourceState(updateUserStateFlag)
 		}
 
 		if outputFormat != OutputFormatJSON {

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -318,12 +318,12 @@ type CreateTopicRequest struct {
 
 // UpdateTopicRequest represents the request body for updating a topic
 type UpdateTopicRequest struct {
-	Name                   string   `json:"name,omitempty"`
-	ComponentTypes         []string `json:"component_types,omitempty"`
-	ComponentTypesOptional []string `json:"component_types_optional,omitempty"`
-	ExportControl          *bool    `json:"export_control,omitempty"`
-	NextTopicID            string   `json:"next_topic_id,omitempty"`
-	State                  string   `json:"state,omitempty"`
+	Name                   string        `json:"name,omitempty"`
+	ComponentTypes         []string      `json:"component_types,omitempty"`
+	ComponentTypesOptional []string      `json:"component_types_optional,omitempty"`
+	ExportControl          *bool         `json:"export_control,omitempty"`
+	NextTopicID            string        `json:"next_topic_id,omitempty"`
+	State                  ResourceState `json:"state,omitempty"`
 }
 
 // ComponentTypeResponse represents a single component type response from the API
@@ -338,8 +338,8 @@ type CreateComponentTypeRequest struct {
 
 // UpdateComponentTypeRequest represents the request body for updating a component type
 type UpdateComponentTypeRequest struct {
-	Name  string `json:"name,omitempty"`
-	State string `json:"state,omitempty"`
+	Name  string        `json:"name,omitempty"`
+	State ResourceState `json:"state,omitempty"`
 }
 
 // ComponentResponse represents a single component response from the API
@@ -349,21 +349,21 @@ type ComponentResponse struct {
 
 // CreateComponentRequest represents the request body for creating a new component
 type CreateComponentRequest struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	TopicID string `json:"topic_id"`
-	Version string `json:"version,omitempty"`
-	URL     string `json:"url,omitempty"`
-	State   string `json:"state,omitempty"`
+	Name    string        `json:"name"`
+	Type    string        `json:"type"`
+	TopicID string        `json:"topic_id"`
+	Version string        `json:"version,omitempty"`
+	URL     string        `json:"url,omitempty"`
+	State   ResourceState `json:"state,omitempty"`
 }
 
 // UpdateComponentRequest represents the request body for updating a component
 type UpdateComponentRequest struct {
-	Name    string   `json:"name,omitempty"`
-	State   string   `json:"state,omitempty"`
-	URL     string   `json:"url,omitempty"`
-	Version string   `json:"version,omitempty"`
-	Tags    []string `json:"tags,omitempty"`
+	Name    string        `json:"name,omitempty"`
+	State   ResourceState `json:"state,omitempty"`
+	URL     string        `json:"url,omitempty"`
+	Version string        `json:"version,omitempty"`
+	Tags    []string      `json:"tags,omitempty"`
 }
 
 // JobResponse represents a single job response from the API
@@ -415,6 +415,14 @@ type CreateJobRequest struct {
 type CreateJobResponse struct {
 	Job Job `json:"job"`
 }
+
+// ResourceState represents the valid states for DCI resources (topics, components, teams, etc.)
+type ResourceState string
+
+const (
+	ResourceStateActive   ResourceState = "active"
+	ResourceStateInactive ResourceState = "inactive"
+)
 
 // JobState represents the valid job states
 type JobState string
@@ -511,8 +519,8 @@ type CreateRemoteCIRequest struct {
 
 // UpdateRemoteCIRequest represents the request body for updating a remote CI
 type UpdateRemoteCIRequest struct {
-	Name  string `json:"name,omitempty"`
-	State string `json:"state,omitempty"`
+	Name  string        `json:"name,omitempty"`
+	State ResourceState `json:"state,omitempty"`
 }
 
 // Team represents a team in DCI
@@ -547,9 +555,9 @@ type CreateTeamRequest struct {
 
 // UpdateTeamRequest represents the request body for updating a team
 type UpdateTeamRequest struct {
-	Name    string `json:"name,omitempty"`
-	Country string `json:"country,omitempty"`
-	State   string `json:"state,omitempty"`
+	Name    string        `json:"name,omitempty"`
+	Country string        `json:"country,omitempty"`
+	State   ResourceState `json:"state,omitempty"`
 }
 
 // User represents a user in DCI
@@ -588,11 +596,11 @@ type CreateUserRequest struct {
 
 // UpdateUserRequest represents the request body for updating a user
 type UpdateUserRequest struct {
-	Name     string `json:"name,omitempty"`
-	Email    string `json:"email,omitempty"`
-	Fullname string `json:"fullname,omitempty"`
-	Timezone string `json:"timezone,omitempty"`
-	State    string `json:"state,omitempty"`
+	Name     string        `json:"name,omitempty"`
+	Email    string        `json:"email,omitempty"`
+	Fullname string        `json:"fullname,omitempty"`
+	Timezone string        `json:"timezone,omitempty"`
+	State    ResourceState `json:"state,omitempty"`
 }
 
 // ProductsResponse represents the response from getting products

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -58,6 +58,31 @@ func TestStringOrSlice_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestResourceStateConstants(t *testing.T) {
+	if ResourceStateActive != "active" {
+		t.Errorf("expected 'active', got %q", ResourceStateActive)
+	}
+	if ResourceStateInactive != "inactive" {
+		t.Errorf("expected 'inactive', got %q", ResourceStateInactive)
+	}
+}
+
+func TestResourceStateJSON(t *testing.T) {
+	req := UpdateComponentTypeRequest{Name: "test", State: ResourceStateActive}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded UpdateComponentTypeRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decoded.State != ResourceStateActive {
+		t.Errorf("expected %q, got %q", ResourceStateActive, decoded.State)
+	}
+}
+
 func TestStringOrSlice_UnmarshalJSON_Error(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- Add `ResourceState` type with `ResourceStateActive` and `ResourceStateInactive` constants, matching the existing `JobState` pattern
- Update all request structs (`UpdateTopicRequest`, `UpdateComponentTypeRequest`, `CreateComponentRequest`, `UpdateComponentRequest`, `UpdateRemoteCIRequest`, `UpdateTeamRequest`, `UpdateUserRequest`) to use `ResourceState` instead of raw strings
- Update CLI command handlers to cast string flags to `ResourceState`
- Add tests for the new constants and JSON round-trip

## Test plan

- [x] `make test` — all 202 tests pass
- [x] `make lint` — 0 issues