### PR TITLE
feat: add --version flag and improve root command description

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p dist
           BINARY_NAME=go-dci
           OUTPUT="dist/${BINARY_NAME}"
-          go build -trimpath -ldflags "-s -w" -o "$OUTPUT" .
+          go build -trimpath -ldflags "-s -w -X github.com/sebrandon1/go-dci/cmd.Version=${GITHUB_REF_NAME}" -o "$OUTPUT" .
 
       - name: Package
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP_NAME=go-dci
+VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 GO_FILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 .PHONY: vet build lint test clean run
@@ -7,7 +8,7 @@ vet:
 	go vet $(GO_FILES)
 
 build:
-	go build -o $(APP_NAME)
+	go build -ldflags "-X github.com/sebrandon1/go-dci/cmd.Version=$(VERSION)" -o $(APP_NAME)
 
 lint:
 	golangci-lint run ./cmd ./lib

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+var Version = "dev"
+
 var rootCmd = &cobra.Command{
-	Use:   "dci",
-	Short: "DCI CLI",
+	Use:     "dci",
+	Short:   "CLI and library for the Red Hat Distributed CI API",
+	Version: Version,
 }
 
 var configFile string


### PR DESCRIPTION
## Summary

- Add --version flag using Cobra built-in version support
- Version injected via ldflags from git tags at build time, falling back to dev for plain go build
- Update Makefile build target and release workflow to inject version
- Improve root command description from DCI CLI to CLI and library for the Red Hat Distributed CI API

## Test plan

- [x] ./go-dci --version prints version string
- [x] ./go-dci --help shows improved description
- [x] make test -- all tests pass
- [x] make lint -- 0 issues