### PR TITLE
feat: add container image builds and major tag updates on release

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,0 +1,48 @@
+name: Release container image
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  build-and-push:
+    name: Build and push container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract version tags
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          MAJOR=$(echo "$TAG" | grep -oE '^v[0-9]+')
+          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ steps.version.outputs.tag }}
+          tags: |
+            quay.io/bapalm/go-dci:${{ steps.version.outputs.tag }}
+            quay.io/bapalm/go-dci:${{ steps.version.outputs.major }}
+            quay.io/bapalm/go-dci:latest

--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -1,0 +1,40 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  update-major-tag:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Release tag: $TAG_NAME"
+
+          if [[ $TAG_NAME =~ ^v([0-9]+)\. ]]; then
+            MAJOR_VERSION="v${BASH_REMATCH[1]}"
+            echo "Major version: $MAJOR_VERSION"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git tag -d "$MAJOR_VERSION" 2>/dev/null || true
+            git tag -fa "$MAJOR_VERSION" -m "Update $MAJOR_VERSION to $TAG_NAME"
+            git push origin "$MAJOR_VERSION" --force
+
+            echo "Successfully updated $MAJOR_VERSION tag to point to $TAG_NAME"
+          else
+            echo "Tag $TAG_NAME does not match expected format (vX.Y.Z), skipping"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.26 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/sebrandon1/go-dci/cmd.Version=${VERSION}" -o /go-dci .
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go-dci /go-dci
+ENTRYPOINT ["/go-dci"]


### PR DESCRIPTION
## Summary

- Add Dockerfile with multi-stage build (golang:1.26 builder + scratch runtime) with version injection via ldflags
- Add release-image workflow: builds multi-arch images (linux/amd64, linux/arm64) and pushes to quay.io/bapalm/go-dci with version, major, and latest tags on release
- Add update-major-tag workflow: auto-updates major version git tag (e.g., v1) to point to latest release

Matches the release automation pattern from [go-quay](https://github.com/sebrandon1/go-quay/tree/main/.github/workflows).

## Test plan

- [x] Dockerfile builds locally: docker build --build-arg VERSION=test -t go-dci:test .
- [x] Version flag works in container: docker run go-dci:test --version prints dci version test
- [x] make lint -- 0 issues
- [ ] On next release: verify image at quay.io/bapalm/go-dci and major tag update