### PR TITLE
fix: use RunE for proper non-zero exit codes on errors

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -28,16 +28,14 @@ var (
 var getComponentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Get a specific component by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getComponentIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -48,8 +46,7 @@ var getComponentCmd = &cobra.Command{
 
 		response, err := client.GetComponent(getComponentIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get component: %v\n", err)
-			return
+			return fmt.Errorf("failed to get component: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -57,32 +54,30 @@ var getComponentCmd = &cobra.Command{
 		} else {
 			printComponentStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createComponentCmd = &cobra.Command{
 	Use:   "create-component",
 	Short: "Create a new component in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createComponentName == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		if createComponentType == "" {
-			fmt.Println("Error: --type is required")
-			return
+			return fmt.Errorf("--type is required")
 		}
 
 		if createComponentTopicID == "" {
-			fmt.Println("Error: --topic-id is required")
-			return
+			return fmt.Errorf("--topic-id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -93,8 +88,7 @@ var createComponentCmd = &cobra.Command{
 
 		response, err := client.CreateComponent(createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
 		if err != nil {
-			fmt.Printf("Failed to create component: %v\n", err)
-			return
+			return fmt.Errorf("failed to create component: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -103,22 +97,22 @@ var createComponentCmd = &cobra.Command{
 			fmt.Println("Component created successfully!")
 			printComponentStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateComponentCmd = &cobra.Command{
 	Use:   "update-component",
 	Short: "Update an existing component in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateComponentIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -147,8 +141,7 @@ var updateComponentCmd = &cobra.Command{
 
 		response, err := client.UpdateComponent(updateComponentIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update component: %v\n", err)
-			return
+			return fmt.Errorf("failed to update component: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -157,22 +150,22 @@ var updateComponentCmd = &cobra.Command{
 			fmt.Println("Component updated successfully!")
 			printComponentStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteComponentCmd = &cobra.Command{
 	Use:   "delete-component",
 	Short: "Delete a component from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteComponentIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -183,8 +176,7 @@ var deleteComponentCmd = &cobra.Command{
 
 		err = client.DeleteComponent(deleteComponentIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete component: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete component: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -194,6 +186,8 @@ var deleteComponentCmd = &cobra.Command{
 		} else {
 			fmt.Println("Component deleted successfully!")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -22,16 +22,14 @@ var (
 var getComponentTypeCmd = &cobra.Command{
 	Use:   "componenttype",
 	Short: "Get a specific component type by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getComponentTypeIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -42,8 +40,7 @@ var getComponentTypeCmd = &cobra.Command{
 
 		response, err := client.GetComponentType(getComponentTypeIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get component type: %v\n", err)
-			return
+			return fmt.Errorf("failed to get component type: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -51,22 +48,22 @@ var getComponentTypeCmd = &cobra.Command{
 		} else {
 			printComponentTypeStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createComponentTypeCmd = &cobra.Command{
 	Use:   "create-componenttype",
 	Short: "Create a new component type in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createComponentTypeName == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -77,8 +74,7 @@ var createComponentTypeCmd = &cobra.Command{
 
 		response, err := client.CreateComponentType(createComponentTypeName)
 		if err != nil {
-			fmt.Printf("Failed to create component type: %v\n", err)
-			return
+			return fmt.Errorf("failed to create component type: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -87,22 +83,22 @@ var createComponentTypeCmd = &cobra.Command{
 			fmt.Println("Component type created successfully!")
 			printComponentTypeStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateComponentTypeCmd = &cobra.Command{
 	Use:   "update-componenttype",
 	Short: "Update an existing component type in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateComponentTypeIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -121,8 +117,7 @@ var updateComponentTypeCmd = &cobra.Command{
 
 		response, err := client.UpdateComponentType(updateComponentTypeIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update component type: %v\n", err)
-			return
+			return fmt.Errorf("failed to update component type: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -131,22 +126,22 @@ var updateComponentTypeCmd = &cobra.Command{
 			fmt.Println("Component type updated successfully!")
 			printComponentTypeStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteComponentTypeCmd = &cobra.Command{
 	Use:   "delete-componenttype",
 	Short: "Delete a component type from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteComponentTypeIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -157,8 +152,7 @@ var deleteComponentTypeCmd = &cobra.Command{
 
 		err = client.DeleteComponentType(deleteComponentTypeIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete component type: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete component type: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -168,6 +162,8 @@ var deleteComponentTypeCmd = &cobra.Command{
 		} else {
 			fmt.Println("Component type deleted successfully!")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,58 +27,60 @@ var configCmd = &cobra.Command{
 var setCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set a key value pair to the configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accesskey, _ := cmd.Flags().GetString("accesskey")
 		secretkey, _ := cmd.Flags().GetString("secretkey")
 
 		if accesskey != "" {
 			if err := UpdateConfigValue("accesskey", accesskey); err != nil {
-				fmt.Printf("Error setting accesskey: %v\n", err)
-				return
+				return fmt.Errorf("setting accesskey: %v", err)
 			}
 			fmt.Println("Access key updated successfully")
 		}
 
 		if secretkey != "" {
 			if err := UpdateConfigValue("secretkey", secretkey); err != nil {
-				fmt.Printf("Error setting secretkey: %v\n", err)
-				return
+				return fmt.Errorf("setting secretkey: %v", err)
 			}
 			fmt.Println("Secret key updated successfully")
 		}
+
+		return nil
 	},
 }
 
 var unsetCmd = &cobra.Command{
 	Use:   "unset",
 	Short: "Unset a key value pair from the configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		key, _ := cmd.Flags().GetString("key")
 		if key == "" {
-			fmt.Println("Error: --key flag is required")
-			return
+			return fmt.Errorf("--key flag is required")
 		}
 
 		if !viper.IsSet(key) {
 			fmt.Printf("Key '%s' does not exist in configuration\n", key)
-			return
+			return nil
 		}
 
 		viper.Set(key, nil)
 		err := viper.WriteConfig()
 		if err != nil {
-			fmt.Printf("Error writing config: %v\n", err)
-			return
+			return fmt.Errorf("writing config: %v", err)
 		}
 		fmt.Printf("Unset key '%s' from configuration\n", key)
+
+		return nil
 	},
 }
 
 var viewCmd = &cobra.Command{
 	Use:   "view",
 	Short: "View the configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		viper.Debug()
+
+		return nil
 	},
 }
 

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -19,16 +19,14 @@ var (
 var getFileCmd = &cobra.Command{
 	Use:   "file",
 	Short: "Download a file by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getFileIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -39,14 +37,12 @@ var getFileCmd = &cobra.Command{
 
 		content, contentType, err := client.GetFile(getFileIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get file: %v\n", err)
-			return
+			return fmt.Errorf("failed to get file: %v", err)
 		}
 
 		if getFileOutputPath != "" {
 			if err := os.WriteFile(getFileOutputPath, content, 0644); err != nil {
-				fmt.Printf("Failed to write file: %v\n", err)
-				return
+				return fmt.Errorf("failed to write file: %v", err)
 			}
 			fmt.Printf("File saved to: %s\n", getFileOutputPath)
 		} else if outputFormat == OutputFormatJSON {
@@ -63,22 +59,22 @@ var getFileCmd = &cobra.Command{
 			fmt.Printf("Size:          %d bytes\n", len(content))
 			fmt.Println("Use --output <path> to save the file content")
 		}
+
+		return nil
 	},
 }
 
 var deleteFileCmd = &cobra.Command{
 	Use:   "delete-file",
 	Short: "Delete a file from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteFileIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -89,8 +85,7 @@ var deleteFileCmd = &cobra.Command{
 
 		err = client.DeleteFile(deleteFileIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete file: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete file: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -100,6 +95,8 @@ var deleteFileCmd = &cobra.Command{
 		} else {
 			fmt.Println("File deleted successfully!")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,11 +33,10 @@ var (
 var getTopicsCmd = &cobra.Command{
 	Use:   "topics",
 	Short: "Get all topics from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -48,8 +47,7 @@ var getTopicsCmd = &cobra.Command{
 
 		topicsResponses, err := client.GetTopics()
 		if err != nil {
-			fmt.Printf("failed to get topics: %v\n", err)
-			return
+			return fmt.Errorf("failed to get topics: %v", err)
 		}
 
 		totalTopics := 0
@@ -63,17 +61,18 @@ var getTopicsCmd = &cobra.Command{
 			printTopicsStdout(topicsResponses)
 			fmt.Printf("Total Topics: %d\n", totalTopics)
 		}
+
+		return nil
 	},
 }
 
 var getComponentTypesCmd = &cobra.Command{
 	Use:   "componenttypes",
 	Short: "Get all component types from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -84,8 +83,7 @@ var getComponentTypesCmd = &cobra.Command{
 
 		componentTypesResponses, err := client.GetComponentTypes()
 		if err != nil {
-			fmt.Printf("failed to get component types: %v\n", err)
-			return
+			return fmt.Errorf("failed to get component types: %v", err)
 		}
 
 		totalComponentTypes := 0
@@ -99,25 +97,25 @@ var getComponentTypesCmd = &cobra.Command{
 			printComponentTypesStdout(componentTypesResponses)
 			fmt.Printf("Total Component Types: %d\n", totalComponentTypes)
 		}
+
+		return nil
 	},
 }
 
 var getIdentityCmd = &cobra.Command{
 	Use:   "identity",
 	Short: "Verify authentication and display current identity information",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
 
 		identity, err := client.GetIdentity()
 		if err != nil {
-			fmt.Printf("Authentication failed: %v\n", err)
-			return
+			return fmt.Errorf("authentication failed: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -125,17 +123,18 @@ var getIdentityCmd = &cobra.Command{
 		} else {
 			printIdentityStdout(identity)
 		}
+
+		return nil
 	},
 }
 
 var getOcpCountCmd = &cobra.Command{
 	Use:   "ocpcount",
 	Short: "Get the count of jobs for each OCP version",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if outputFormat != OutputFormatJSON {
@@ -144,16 +143,14 @@ var getOcpCountCmd = &cobra.Command{
 
 		daysBackLimit, err := strconv.Atoi(ageInDays)
 		if err != nil {
-			fmt.Printf("Error: invalid age value '%s': %v\n", ageInDays, err)
-			return
+			return fmt.Errorf("invalid age value '%s': %v", ageInDays, err)
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
 
 		jobsResponses, err := client.GetJobs(daysBackLimit)
 		if err != nil {
-			fmt.Printf("Error getting jobs: %v\n", err)
-			return
+			return fmt.Errorf("getting jobs: %v", err)
 		}
 
 		ocpVersionCount := countOcpVersions(jobsResponses)
@@ -163,17 +160,18 @@ var getOcpCountCmd = &cobra.Command{
 		} else {
 			printOcpVersionCountJSON(ocpVersionCount)
 		}
+
+		return nil
 	},
 }
 
 var getComponentsCmd = &cobra.Command{
 	Use:   "components",
 	Short: "Get all components, optionally filtered by topic ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -193,8 +191,7 @@ var getComponentsCmd = &cobra.Command{
 		}
 
 		if err != nil {
-			fmt.Printf("failed to get components: %v\n", err)
-			return
+			return fmt.Errorf("failed to get components: %v", err)
 		}
 
 		totalComponents := 0
@@ -208,17 +205,18 @@ var getComponentsCmd = &cobra.Command{
 			printComponentsStdout(componentsResponses)
 			fmt.Printf("Total Components: %d\n", totalComponents)
 		}
+
+		return nil
 	},
 }
 
 var getJobsCmd = &cobra.Command{
 	Use:   "jobs",
 	Short: "Get all jobs with a specific age in days or date range",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		var jsonOutput lib.JobsJsonOutput
@@ -234,14 +232,12 @@ var getJobsCmd = &cobra.Command{
 		if startDate != "" && endDate != "" {
 			parsedStart, err := time.Parse(dateFormatDay, startDate)
 			if err != nil {
-				fmt.Printf("Error: invalid start-date '%s' (expected YYYY-MM-DD): %v\n", startDate, err)
-				return
+				return fmt.Errorf("invalid start-date '%s' (expected YYYY-MM-DD): %v", startDate, err)
 			}
 
 			parsedEnd, err := time.Parse(dateFormatDay, endDate)
 			if err != nil {
-				fmt.Printf("Error: invalid end-date '%s' (expected YYYY-MM-DD): %v\n", endDate, err)
-				return
+				return fmt.Errorf("invalid end-date '%s' (expected YYYY-MM-DD): %v", endDate, err)
 			}
 
 			// Include the entire end date by advancing to the start of the next day
@@ -253,12 +249,10 @@ var getJobsCmd = &cobra.Command{
 
 			jobsResponses, err = client.GetJobsByDate(parsedStart, parsedEnd)
 			if err != nil {
-				fmt.Printf("failed to get jobs: %v\n", err)
-				return
+				return fmt.Errorf("failed to get jobs: %v", err)
 			}
 		} else if startDate != "" || endDate != "" {
-			fmt.Println("Error: both --start-date and --end-date must be provided together")
-			return
+			return fmt.Errorf("both --start-date and --end-date must be provided together")
 		} else {
 			if outputFormat != OutputFormatJSON {
 				fmt.Printf("Getting all jobs from DCI that are %s days old\n", ageInDays)
@@ -266,14 +260,12 @@ var getJobsCmd = &cobra.Command{
 
 			daysBackLimit, err := strconv.Atoi(ageInDays)
 			if err != nil {
-				fmt.Printf("Error: invalid age value '%s': %v\n", ageInDays, err)
-				return
+				return fmt.Errorf("invalid age value '%s': %v", ageInDays, err)
 			}
 
 			jobsResponses, err = client.GetJobs(daysBackLimit)
 			if err != nil {
-				fmt.Printf("failed to get jobs: %v\n", err)
-				return
+				return fmt.Errorf("failed to get jobs: %v", err)
 			}
 		}
 
@@ -308,11 +300,12 @@ var getJobsCmd = &cobra.Command{
 		} else {
 			jsonOutputBytes, err := json.Marshal(jsonOutput)
 			if err != nil {
-				fmt.Printf("Error marshaling JSON output: %v\n", err)
-				return
+				return fmt.Errorf("failed to marshal JSON output: %v", err)
 			}
 			fmt.Println(string(jsonOutputBytes))
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -24,16 +24,14 @@ var (
 var getJobCmd = &cobra.Command{
 	Use:   "job",
 	Short: "Get a specific job by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getJobIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -44,8 +42,7 @@ var getJobCmd = &cobra.Command{
 
 		response, err := client.GetJob(getJobIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get job: %v\n", err)
-			return
+			return fmt.Errorf("failed to get job: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -53,22 +50,22 @@ var getJobCmd = &cobra.Command{
 		} else {
 			printJobStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateJobCmd = &cobra.Command{
 	Use:   "update-job",
 	Short: "Update an existing job in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateJobIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -91,8 +88,7 @@ var updateJobCmd = &cobra.Command{
 
 		response, err := client.UpdateJob(updateJobIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update job: %v\n", err)
-			return
+			return fmt.Errorf("failed to update job: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -101,22 +97,22 @@ var updateJobCmd = &cobra.Command{
 			fmt.Println("Job updated successfully!")
 			printJobStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteJobCmd = &cobra.Command{
 	Use:   "delete-job",
 	Short: "Delete a job from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteJobIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -127,8 +123,7 @@ var deleteJobCmd = &cobra.Command{
 
 		err = client.DeleteJob(deleteJobIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete job: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete job: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -138,22 +133,22 @@ var deleteJobCmd = &cobra.Command{
 		} else {
 			fmt.Println("Job deleted successfully!")
 		}
+
+		return nil
 	},
 }
 
 var scheduleJobCmd = &cobra.Command{
 	Use:   "schedule-job",
 	Short: "Schedule a job with auto-selected components",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if scheduleJobTopicID == "" {
-			fmt.Println("Error: --topic-id is required")
-			return
+			return fmt.Errorf("--topic-id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -164,8 +159,7 @@ var scheduleJobCmd = &cobra.Command{
 
 		response, err := client.ScheduleJob(scheduleJobTopicID)
 		if err != nil {
-			fmt.Printf("Failed to schedule job: %v\n", err)
-			return
+			return fmt.Errorf("failed to schedule job: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -174,22 +168,22 @@ var scheduleJobCmd = &cobra.Command{
 			fmt.Println("Job scheduled successfully!")
 			printCreateJobStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var getJobFilesCmd = &cobra.Command{
 	Use:   "job-files",
 	Short: "Get all files for a specific job",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if jobFilesIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -200,8 +194,7 @@ var getJobFilesCmd = &cobra.Command{
 
 		response, err := client.GetJobFiles(jobFilesIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get job files: %v\n", err)
-			return
+			return fmt.Errorf("failed to get job files: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -209,6 +202,8 @@ var getJobFilesCmd = &cobra.Command{
 		} else {
 			printFilesStdout(response)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -17,11 +17,10 @@ var (
 var getJobStatesCmd = &cobra.Command{
 	Use:   "jobstates",
 	Short: "Get job states, optionally filtered by job ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -36,8 +35,7 @@ var getJobStatesCmd = &cobra.Command{
 
 		response, err := client.GetJobStates(getJobStatesJobIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get job states: %v\n", err)
-			return
+			return fmt.Errorf("failed to get job states: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -45,6 +43,8 @@ var getJobStatesCmd = &cobra.Command{
 		} else {
 			printJobStatesStdout(response)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -26,16 +26,14 @@ var (
 var createJobCmd = &cobra.Command{
 	Use:   "create-job",
 	Short: "Create a new job in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createJobTopicID == "" {
-			fmt.Println("Error: --topic-id is required")
-			return
+			return fmt.Errorf("--topic-id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -55,8 +53,7 @@ var createJobCmd = &cobra.Command{
 
 		response, err := client.CreateJob(createJobTopicID, componentIDs, createJobComment)
 		if err != nil {
-			fmt.Printf("Failed to create job: %v\n", err)
-			return
+			return fmt.Errorf("failed to create job: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -64,27 +61,26 @@ var createJobCmd = &cobra.Command{
 		} else {
 			printCreateJobStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateJobStateCmd = &cobra.Command{
 	Use:   "update-job-state",
 	Short: "Update the state of a job (pre-run, running, success, failure, etc.)",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateJobStateJobID == "" {
-			fmt.Println("Error: --job-id is required")
-			return
+			return fmt.Errorf("--job-id is required")
 		}
 
 		if updateJobStateStatus == "" {
-			fmt.Println("Error: --status is required")
-			return
+			return fmt.Errorf("--status is required")
 		}
 
 		// Validate status
@@ -97,8 +93,7 @@ var updateJobStateCmd = &cobra.Command{
 			}
 		}
 		if !isValid {
-			fmt.Printf("Error: invalid status '%s'. Valid values: %s\n", updateJobStateStatus, strings.Join(validStatuses, ", "))
-			return
+			return fmt.Errorf("invalid status '%s'. Valid values: %s", updateJobStateStatus, strings.Join(validStatuses, ", "))
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -109,8 +104,7 @@ var updateJobStateCmd = &cobra.Command{
 
 		response, err := client.UpdateJobState(updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
 		if err != nil {
-			fmt.Printf("Failed to update job state: %v\n", err)
-			return
+			return fmt.Errorf("failed to update job state: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -118,27 +112,26 @@ var updateJobStateCmd = &cobra.Command{
 		} else {
 			printJobStateStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var uploadFileCmd = &cobra.Command{
 	Use:   "upload-file",
 	Short: "Upload a file (e.g., test results) to a job in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if uploadFileJobID == "" {
-			fmt.Println("Error: --job-id is required")
-			return
+			return fmt.Errorf("--job-id is required")
 		}
 
 		if uploadFilePath == "" {
-			fmt.Println("Error: --file is required")
-			return
+			return fmt.Errorf("--file is required")
 		}
 
 		// Default mime type for test results
@@ -154,8 +147,7 @@ var uploadFileCmd = &cobra.Command{
 
 		response, err := client.UploadFile(uploadFileJobID, uploadFilePath, uploadFileMimeType)
 		if err != nil {
-			fmt.Printf("Failed to upload file: %v\n", err)
-			return
+			return fmt.Errorf("failed to upload file: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -163,6 +155,8 @@ var uploadFileCmd = &cobra.Command{
 		} else {
 			printUploadFileStdout(response)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -17,11 +17,10 @@ var (
 var getProductsCmd = &cobra.Command{
 	Use:   "products",
 	Short: "Get all products from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -32,8 +31,7 @@ var getProductsCmd = &cobra.Command{
 
 		response, err := client.GetProducts()
 		if err != nil {
-			fmt.Printf("Failed to get products: %v\n", err)
-			return
+			return fmt.Errorf("failed to get products: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -41,22 +39,22 @@ var getProductsCmd = &cobra.Command{
 		} else {
 			printProductsStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var getProductCmd = &cobra.Command{
 	Use:   "product",
 	Short: "Get a specific product by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getProductIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -67,8 +65,7 @@ var getProductCmd = &cobra.Command{
 
 		response, err := client.GetProduct(getProductIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get product: %v\n", err)
-			return
+			return fmt.Errorf("failed to get product: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -76,6 +73,8 @@ var getProductCmd = &cobra.Command{
 		} else {
 			printProductStdout(response)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -11,23 +11,22 @@ import (
 
 // Variables for remoteci command flags
 var (
-	getRemoteCIsCmd_IDFlag       string
-	createRemoteCINameFlag       string
-	createRemoteCITeamIDFlag     string
-	updateRemoteCIIDFlag         string
-	updateRemoteCINameFlag       string
-	updateRemoteCIStateFlag      string
-	deleteRemoteCIIDFlag         string
+	getRemoteCIsCmd_IDFlag   string
+	createRemoteCINameFlag   string
+	createRemoteCITeamIDFlag string
+	updateRemoteCIIDFlag     string
+	updateRemoteCINameFlag   string
+	updateRemoteCIStateFlag  string
+	deleteRemoteCIIDFlag     string
 )
 
 var getRemoteCIsCmd = &cobra.Command{
 	Use:   "remotecis",
 	Short: "Get all remote CIs from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -38,8 +37,7 @@ var getRemoteCIsCmd = &cobra.Command{
 
 		response, err := client.GetRemoteCIs()
 		if err != nil {
-			fmt.Printf("Failed to get remote CIs: %v\n", err)
-			return
+			return fmt.Errorf("failed to get remote CIs: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -47,22 +45,22 @@ var getRemoteCIsCmd = &cobra.Command{
 		} else {
 			printRemoteCIsStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var getRemoteCICmd = &cobra.Command{
 	Use:   "remoteci",
 	Short: "Get a specific remote CI by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getRemoteCIsCmd_IDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -73,8 +71,7 @@ var getRemoteCICmd = &cobra.Command{
 
 		response, err := client.GetRemoteCI(getRemoteCIsCmd_IDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get remote CI: %v\n", err)
-			return
+			return fmt.Errorf("failed to get remote CI: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -82,26 +79,25 @@ var getRemoteCICmd = &cobra.Command{
 		} else {
 			printRemoteCIStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createRemoteCICmd = &cobra.Command{
 	Use:   "create-remoteci",
 	Short: "Create a new remote CI in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createRemoteCINameFlag == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if createRemoteCITeamIDFlag == "" {
-			fmt.Println("Error: --team-id is required")
-			return
+			return fmt.Errorf("--team-id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -112,8 +108,7 @@ var createRemoteCICmd = &cobra.Command{
 
 		response, err := client.CreateRemoteCI(createRemoteCINameFlag, createRemoteCITeamIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to create remote CI: %v\n", err)
-			return
+			return fmt.Errorf("failed to create remote CI: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -122,22 +117,22 @@ var createRemoteCICmd = &cobra.Command{
 			fmt.Println("Remote CI created successfully!")
 			printRemoteCIStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateRemoteCICmd = &cobra.Command{
 	Use:   "update-remoteci",
 	Short: "Update an existing remote CI in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateRemoteCIIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -156,8 +151,7 @@ var updateRemoteCICmd = &cobra.Command{
 
 		response, err := client.UpdateRemoteCI(updateRemoteCIIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update remote CI: %v\n", err)
-			return
+			return fmt.Errorf("failed to update remote CI: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -166,22 +160,22 @@ var updateRemoteCICmd = &cobra.Command{
 			fmt.Println("Remote CI updated successfully!")
 			printRemoteCIStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteRemoteCICmd = &cobra.Command{
 	Use:   "delete-remoteci",
 	Short: "Delete a remote CI from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteRemoteCIIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -192,8 +186,7 @@ var deleteRemoteCICmd = &cobra.Command{
 
 		err = client.DeleteRemoteCI(deleteRemoteCIIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete remote CI: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete remote CI: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -203,6 +196,8 @@ var deleteRemoteCICmd = &cobra.Command{
 		} else {
 			fmt.Println("Remote CI deleted successfully!")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -11,22 +11,21 @@ import (
 
 // Variables for team command flags
 var (
-	getTeamIDFlag      string
-	createTeamNameFlag string
-	updateTeamIDFlag   string
-	updateTeamNameFlag string
+	getTeamIDFlag       string
+	createTeamNameFlag  string
+	updateTeamIDFlag    string
+	updateTeamNameFlag  string
 	updateTeamStateFlag string
-	deleteTeamIDFlag   string
+	deleteTeamIDFlag    string
 )
 
 var getTeamsCmd = &cobra.Command{
 	Use:   "teams",
 	Short: "Get all teams from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -37,8 +36,7 @@ var getTeamsCmd = &cobra.Command{
 
 		response, err := client.GetTeams()
 		if err != nil {
-			fmt.Printf("Failed to get teams: %v\n", err)
-			return
+			return fmt.Errorf("failed to get teams: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -46,22 +44,22 @@ var getTeamsCmd = &cobra.Command{
 		} else {
 			printTeamsStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var getTeamCmd = &cobra.Command{
 	Use:   "team",
 	Short: "Get a specific team by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getTeamIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -72,8 +70,7 @@ var getTeamCmd = &cobra.Command{
 
 		response, err := client.GetTeam(getTeamIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get team: %v\n", err)
-			return
+			return fmt.Errorf("failed to get team: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -81,22 +78,22 @@ var getTeamCmd = &cobra.Command{
 		} else {
 			printTeamStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createTeamCmd = &cobra.Command{
 	Use:   "create-team",
 	Short: "Create a new team in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createTeamNameFlag == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -107,8 +104,7 @@ var createTeamCmd = &cobra.Command{
 
 		response, err := client.CreateTeam(createTeamNameFlag)
 		if err != nil {
-			fmt.Printf("Failed to create team: %v\n", err)
-			return
+			return fmt.Errorf("failed to create team: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -117,22 +113,22 @@ var createTeamCmd = &cobra.Command{
 			fmt.Println("Team created successfully!")
 			printTeamStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateTeamCmd = &cobra.Command{
 	Use:   "update-team",
 	Short: "Update an existing team in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateTeamIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -151,8 +147,7 @@ var updateTeamCmd = &cobra.Command{
 
 		response, err := client.UpdateTeam(updateTeamIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update team: %v\n", err)
-			return
+			return fmt.Errorf("failed to update team: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -161,22 +156,22 @@ var updateTeamCmd = &cobra.Command{
 			fmt.Println("Team updated successfully!")
 			printTeamStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteTeamCmd = &cobra.Command{
 	Use:   "delete-team",
 	Short: "Delete a team from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteTeamIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -187,8 +182,7 @@ var deleteTeamCmd = &cobra.Command{
 
 		err = client.DeleteTeam(deleteTeamIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete team: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete team: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -198,6 +192,8 @@ var deleteTeamCmd = &cobra.Command{
 		} else {
 			fmt.Println("Team deleted successfully!")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -24,16 +24,14 @@ var (
 var getTopicCmd = &cobra.Command{
 	Use:   "topic",
 	Short: "Get a specific topic by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getTopicIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -44,8 +42,7 @@ var getTopicCmd = &cobra.Command{
 
 		response, err := client.GetTopic(getTopicIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get topic: %v\n", err)
-			return
+			return fmt.Errorf("failed to get topic: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -53,27 +50,26 @@ var getTopicCmd = &cobra.Command{
 		} else {
 			printTopicStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createTopicCmd = &cobra.Command{
 	Use:   "create-topic",
 	Short: "Create a new topic in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createTopicName == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 
 		if createTopicProductID == "" {
-			fmt.Println("Error: --product-id is required")
-			return
+			return fmt.Errorf("--product-id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -93,8 +89,7 @@ var createTopicCmd = &cobra.Command{
 
 		response, err := client.CreateTopic(createTopicName, createTopicProductID, componentTypes)
 		if err != nil {
-			fmt.Printf("Failed to create topic: %v\n", err)
-			return
+			return fmt.Errorf("failed to create topic: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -103,22 +98,22 @@ var createTopicCmd = &cobra.Command{
 			fmt.Println("Topic created successfully!")
 			printTopicStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateTopicCmd = &cobra.Command{
 	Use:   "update-topic",
 	Short: "Update an existing topic in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getTopicIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -134,8 +129,7 @@ var updateTopicCmd = &cobra.Command{
 
 		response, err := client.UpdateTopic(getTopicIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update topic: %v\n", err)
-			return
+			return fmt.Errorf("failed to update topic: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -144,22 +138,22 @@ var updateTopicCmd = &cobra.Command{
 			fmt.Println("Topic updated successfully!")
 			printTopicStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteTopicCmd = &cobra.Command{
 	Use:   "delete-topic",
 	Short: "Delete a topic from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteTopicIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -170,8 +164,7 @@ var deleteTopicCmd = &cobra.Command{
 
 		err = client.DeleteTopic(deleteTopicIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete topic: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete topic: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -181,22 +174,22 @@ var deleteTopicCmd = &cobra.Command{
 		} else {
 			fmt.Println("Topic deleted successfully!")
 		}
+
+		return nil
 	},
 }
 
 var getTopicComponentsCmd = &cobra.Command{
 	Use:   "topic-components",
 	Short: "Get all components for a specific topic",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if topicComponentsIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -207,8 +200,7 @@ var getTopicComponentsCmd = &cobra.Command{
 
 		componentsResponses, err := client.GetTopicComponents(topicComponentsIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get topic components: %v\n", err)
-			return
+			return fmt.Errorf("failed to get topic components: %v", err)
 		}
 
 		totalComponents := 0
@@ -222,6 +214,8 @@ var getTopicComponentsCmd = &cobra.Command{
 			printComponentsStdout(componentsResponses)
 			fmt.Printf("Total Components: %d\n", totalComponents)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -28,11 +28,10 @@ var (
 var getUsersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Get all users from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -43,8 +42,7 @@ var getUsersCmd = &cobra.Command{
 
 		response, err := client.GetUsers()
 		if err != nil {
-			fmt.Printf("Failed to get users: %v\n", err)
-			return
+			return fmt.Errorf("failed to get users: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -52,22 +50,22 @@ var getUsersCmd = &cobra.Command{
 		} else {
 			printUsersStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var getUserCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Get a specific user by ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if getUserIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -78,8 +76,7 @@ var getUserCmd = &cobra.Command{
 
 		response, err := client.GetUser(getUserIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to get user: %v\n", err)
-			return
+			return fmt.Errorf("failed to get user: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -87,34 +84,31 @@ var getUserCmd = &cobra.Command{
 		} else {
 			printUserStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var createUserCmd = &cobra.Command{
 	Use:   "create-user",
 	Short: "Create a new user in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if createUserNameFlag == "" {
-			fmt.Println("Error: --name is required")
-			return
+			return fmt.Errorf("--name is required")
 		}
 		if createUserEmailFlag == "" {
-			fmt.Println("Error: --email is required")
-			return
+			return fmt.Errorf("--email is required")
 		}
 		if createUserTeamIDFlag == "" {
-			fmt.Println("Error: --team-id is required")
-			return
+			return fmt.Errorf("--team-id is required")
 		}
 		if createUserPasswordFlag == "" {
-			fmt.Println("Error: --password is required")
-			return
+			return fmt.Errorf("--password is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -131,8 +125,7 @@ var createUserCmd = &cobra.Command{
 			createUserPasswordFlag,
 		)
 		if err != nil {
-			fmt.Printf("Failed to create user: %v\n", err)
-			return
+			return fmt.Errorf("failed to create user: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -141,22 +134,22 @@ var createUserCmd = &cobra.Command{
 			fmt.Println("User created successfully!")
 			printUserStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var updateUserCmd = &cobra.Command{
 	Use:   "update-user",
 	Short: "Update an existing user in DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if updateUserIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -181,8 +174,7 @@ var updateUserCmd = &cobra.Command{
 
 		response, err := client.UpdateUser(updateUserIDFlag, updates)
 		if err != nil {
-			fmt.Printf("Failed to update user: %v\n", err)
-			return
+			return fmt.Errorf("failed to update user: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -191,22 +183,22 @@ var updateUserCmd = &cobra.Command{
 			fmt.Println("User updated successfully!")
 			printUserStdout(response)
 		}
+
+		return nil
 	},
 }
 
 var deleteUserCmd = &cobra.Command{
 	Use:   "delete-user",
 	Short: "Delete a user from DCI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 
 		if deleteUserIDFlag == "" {
-			fmt.Println("Error: --id is required")
-			return
+			return fmt.Errorf("--id is required")
 		}
 
 		client := lib.NewClient(accessKey, secretKey)
@@ -217,8 +209,7 @@ var deleteUserCmd = &cobra.Command{
 
 		err = client.DeleteUser(deleteUserIDFlag)
 		if err != nil {
-			fmt.Printf("Failed to delete user: %v\n", err)
-			return
+			return fmt.Errorf("failed to delete user: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -228,6 +219,8 @@ var deleteUserCmd = &cobra.Command{
 		} else {
 			fmt.Println("User deleted successfully!")
 		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
## Summary

- Convert all 50 Cobra commands across 13 files from `Run` to `RunE` so errors return non-zero exit codes
- Previously all commands exited 0 even on failures (missing flags, API errors, invalid input), breaking scripted usage
- Error messages normalized to lowercase Go convention, with `fmt.Errorf` returns instead of `fmt.Println` + bare `return`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `make test` -- all tests pass
- [x] `make lint` -- 0 issues
- [x] No `Run:` remains in any cmd file (all 50 commands use `RunE:`)