### PR TITLE
fix: validate --age and --start-date/--end-date mutual exclusivity

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -137,6 +137,10 @@ var getOcpCountCmd = &cobra.Command{
 			return err
 		}
 
+		if ageInDays == "" {
+			return fmt.Errorf("--age is required")
+		}
+
 		if outputFormat != OutputFormatJSON {
 			fmt.Printf("Getting all jobs from DCI that are %s days old\n", ageInDays)
 		}
@@ -217,6 +221,14 @@ var getJobsCmd = &cobra.Command{
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
+		}
+
+		if ageInDays != "" && (startDate != "" || endDate != "") {
+			return fmt.Errorf("--age and --start-date/--end-date are mutually exclusive")
+		}
+
+		if ageInDays == "" && startDate == "" && endDate == "" {
+			return fmt.Errorf("either --age or --start-date/--end-date is required")
 		}
 
 		var jsonOutput lib.JobsJsonOutput


### PR DESCRIPTION
## Summary

- Add mutual exclusivity check: `--age` and `--start-date/--end-date` now reject conflicting usage with a clear error
- Add required flag check: `jobs` command now requires either `--age` or `--start-date/--end-date` (previously passed empty string to strconv.Atoi)
- Add required flag check: `ocpcount` command now validates `--age` is provided

Previously a user could pass all three flags and `--age` would be silently ignored.

## Test plan

- [x] `make test` -- all tests pass
- [x] `make lint` -- 0 issues