### PR TITLE
refactor: replace log.Fatalf with error returns in JSON print helpers

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/sebrandon1/go-dci/lib"
@@ -50,10 +49,10 @@ var getComponentCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentJSON(response)
-		} else {
-			printComponentStdout(response)
+			return printComponentJSON(response)
 		}
+
+		printComponentStdout(response)
 
 		return nil
 	},
@@ -92,11 +91,11 @@ var createComponentCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentJSON(response)
-		} else {
-			fmt.Println("Component created successfully!")
-			printComponentStdout(response)
+			return printComponentJSON(response)
 		}
+
+		fmt.Println("Component created successfully!")
+		printComponentStdout(response)
 
 		return nil
 	},
@@ -145,11 +144,11 @@ var updateComponentCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentJSON(response)
-		} else {
-			fmt.Println("Component updated successfully!")
-			printComponentStdout(response)
+			return printComponentJSON(response)
 		}
+
+		fmt.Println("Component updated successfully!")
+		printComponentStdout(response)
 
 		return nil
 	},
@@ -209,12 +208,13 @@ func printComponentStdout(response *lib.ComponentResponse) {
 	fmt.Printf("Updated:      %s\n", response.Component.UpdatedAt)
 }
 
-func printComponentJSON(response *lib.ComponentResponse) {
+func printComponentJSON(response *lib.ComponentResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -44,10 +43,10 @@ var getComponentTypeCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentTypeJSON(response)
-		} else {
-			printComponentTypeStdout(response)
+			return printComponentTypeJSON(response)
 		}
+
+		printComponentTypeStdout(response)
 
 		return nil
 	},
@@ -78,11 +77,11 @@ var createComponentTypeCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentTypeJSON(response)
-		} else {
-			fmt.Println("Component type created successfully!")
-			printComponentTypeStdout(response)
+			return printComponentTypeJSON(response)
 		}
+
+		fmt.Println("Component type created successfully!")
+		printComponentTypeStdout(response)
 
 		return nil
 	},
@@ -121,11 +120,11 @@ var updateComponentTypeCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentTypeJSON(response)
-		} else {
-			fmt.Println("Component type updated successfully!")
-			printComponentTypeStdout(response)
+			return printComponentTypeJSON(response)
 		}
+
+		fmt.Println("Component type updated successfully!")
+		printComponentTypeStdout(response)
 
 		return nil
 	},
@@ -176,12 +175,13 @@ func printComponentTypeStdout(response *lib.ComponentTypeResponse) {
 	fmt.Printf("Updated:  %s\n", response.ComponentType.UpdatedAt)
 }
 
-func printComponentTypeJSON(response *lib.ComponentTypeResponse) {
+func printComponentTypeJSON(response *lib.ComponentTypeResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -56,11 +55,11 @@ var getTopicsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTopicsJSON(topicsResponses)
-		} else {
-			printTopicsStdout(topicsResponses)
-			fmt.Printf("Total Topics: %d\n", totalTopics)
+			return printTopicsJSON(topicsResponses)
 		}
+
+		printTopicsStdout(topicsResponses)
+		fmt.Printf("Total Topics: %d\n", totalTopics)
 
 		return nil
 	},
@@ -92,11 +91,11 @@ var getComponentTypesCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentTypesJSON(componentTypesResponses)
-		} else {
-			printComponentTypesStdout(componentTypesResponses)
-			fmt.Printf("Total Component Types: %d\n", totalComponentTypes)
+			return printComponentTypesJSON(componentTypesResponses)
 		}
+
+		printComponentTypesStdout(componentTypesResponses)
+		fmt.Printf("Total Component Types: %d\n", totalComponentTypes)
 
 		return nil
 	},
@@ -119,10 +118,10 @@ var getIdentityCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printIdentityJSON(identity)
-		} else {
-			printIdentityStdout(identity)
+			return printIdentityJSON(identity)
 		}
+
+		printIdentityStdout(identity)
 
 		return nil
 	},
@@ -159,11 +158,11 @@ var getOcpCountCmd = &cobra.Command{
 
 		ocpVersionCount := countOcpVersions(jobsResponses)
 
-		if outputFormat != OutputFormatJSON {
-			printOcpVersionCount(ocpVersionCount)
-		} else {
-			printOcpVersionCountJSON(ocpVersionCount)
+		if outputFormat == OutputFormatJSON {
+			return printOcpVersionCountJSON(ocpVersionCount)
 		}
+
+		printOcpVersionCount(ocpVersionCount)
 
 		return nil
 	},
@@ -204,11 +203,11 @@ var getComponentsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentsJSON(componentsResponses)
-		} else {
-			printComponentsStdout(componentsResponses)
-			fmt.Printf("Total Components: %d\n", totalComponents)
+			return printComponentsJSON(componentsResponses)
 		}
+
+		printComponentsStdout(componentsResponses)
+		fmt.Printf("Total Components: %d\n", totalComponents)
 
 		return nil
 	},
@@ -378,7 +377,7 @@ func printOcpVersionCount(ocpVersionCount map[string]int) {
 	}
 }
 
-func printOcpVersionCountJSON(ocpVersionCount map[string]int) {
+func printOcpVersionCountJSON(ocpVersionCount map[string]int) error {
 	var jsonOutput lib.OcpJsonOutput
 	for _, ocpVersion := range ocpVersionsToLookFor {
 		jo := lib.JsonOcpVersionCount{
@@ -390,9 +389,10 @@ func printOcpVersionCountJSON(ocpVersionCount map[string]int) {
 
 	jsonOutputBytes, err := json.Marshal(jsonOutput)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonOutputBytes))
+	return nil
 }
 
 func extractCommitVersion(componentName string) string {
@@ -417,7 +417,7 @@ func printComponentsStdout(componentsResponses []lib.ComponentsResponse) {
 	}
 }
 
-func printComponentsJSON(componentsResponses []lib.ComponentsResponse) {
+func printComponentsJSON(componentsResponses []lib.ComponentsResponse) error {
 	// Flatten all components into a single slice
 	var allComponents []lib.Components
 	for _, cr := range componentsResponses {
@@ -432,9 +432,10 @@ func printComponentsJSON(componentsResponses []lib.ComponentsResponse) {
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printIdentityStdout(identity *lib.IdentityResponse) {
@@ -460,12 +461,13 @@ func printIdentityStdout(identity *lib.IdentityResponse) {
 	}
 }
 
-func printIdentityJSON(identity *lib.IdentityResponse) {
+func printIdentityJSON(identity *lib.IdentityResponse) error {
 	jsonBytes, err := json.Marshal(identity)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printComponentTypesStdout(componentTypesResponses []lib.ComponentTypesResponse) {
@@ -476,7 +478,7 @@ func printComponentTypesStdout(componentTypesResponses []lib.ComponentTypesRespo
 	}
 }
 
-func printComponentTypesJSON(componentTypesResponses []lib.ComponentTypesResponse) {
+func printComponentTypesJSON(componentTypesResponses []lib.ComponentTypesResponse) error {
 	// Flatten all component types into a single slice
 	var allComponentTypes []lib.ComponentType
 	for _, ctr := range componentTypesResponses {
@@ -491,9 +493,10 @@ func printComponentTypesJSON(componentTypesResponses []lib.ComponentTypesRespons
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printTopicsStdout(topicsResponses []lib.TopicsResponse) {
@@ -505,17 +508,17 @@ func printTopicsStdout(topicsResponses []lib.TopicsResponse) {
 	}
 }
 
-func printTopicsJSON(topicsResponses []lib.TopicsResponse) {
+func printTopicsJSON(topicsResponses []lib.TopicsResponse) error {
 	// Flatten all topics into a single slice using the Topic struct
 	type Topic struct {
-		ID            string   `json:"id"`
-		Name          string   `json:"name"`
-		ProductID     string   `json:"product_id"`
-		ProductName   string   `json:"product_name"`
-		State         string   `json:"state"`
-		ExportControl bool     `json:"export_control"`
-		CreatedAt     string   `json:"created_at,omitempty"`
-		UpdatedAt     string   `json:"updated_at,omitempty"`
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		ProductID     string `json:"product_id"`
+		ProductName   string `json:"product_name"`
+		State         string `json:"state"`
+		ExportControl bool   `json:"export_control"`
+		CreatedAt     string `json:"created_at,omitempty"`
+		UpdatedAt     string `json:"updated_at,omitempty"`
 	}
 
 	var allTopics []Topic
@@ -542,9 +545,10 @@ func printTopicsJSON(topicsResponses []lib.TopicsResponse) {
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/sebrandon1/go-dci/lib"
@@ -46,10 +45,10 @@ var getJobCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printJobJSON(response)
-		} else {
-			printJobStdout(response)
+			return printJobJSON(response)
 		}
+
+		printJobStdout(response)
 
 		return nil
 	},
@@ -92,11 +91,11 @@ var updateJobCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printJobJSON(response)
-		} else {
-			fmt.Println("Job updated successfully!")
-			printJobStdout(response)
+			return printJobJSON(response)
 		}
+
+		fmt.Println("Job updated successfully!")
+		printJobStdout(response)
 
 		return nil
 	},
@@ -163,11 +162,11 @@ var scheduleJobCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printCreateJobJSON(response)
-		} else {
-			fmt.Println("Job scheduled successfully!")
-			printCreateJobStdout(response)
+			return printCreateJobJSON(response)
 		}
+
+		fmt.Println("Job scheduled successfully!")
+		printCreateJobStdout(response)
 
 		return nil
 	},
@@ -198,10 +197,10 @@ var getJobFilesCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printFilesJSON(response)
-		} else {
-			printFilesStdout(response)
+			return printFilesJSON(response)
 		}
+
+		printFilesStdout(response)
 
 		return nil
 	},
@@ -227,12 +226,13 @@ func printJobStdout(response *lib.JobResponse) {
 	fmt.Printf("Updated:      %s\n", response.Job.UpdatedAt)
 }
 
-func printJobJSON(response *lib.JobResponse) {
+func printJobJSON(response *lib.JobResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printFilesStdout(response *lib.FilesResponse) {
@@ -248,12 +248,13 @@ func printFilesStdout(response *lib.FilesResponse) {
 	fmt.Printf("Total Files: %d\n", len(response.Files))
 }
 
-func printFilesJSON(response *lib.FilesResponse) {
+func printFilesJSON(response *lib.FilesResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -39,10 +38,10 @@ var getJobStatesCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printJobStatesJSON(response)
-		} else {
-			printJobStatesStdout(response)
+			return printJobStatesJSON(response)
 		}
+
+		printJobStatesStdout(response)
 
 		return nil
 	},
@@ -61,12 +60,13 @@ func printJobStatesStdout(response *lib.JobStatesResponse) {
 	fmt.Printf("Total Job States: %d\n", len(response.JobStates))
 }
 
-func printJobStatesJSON(response *lib.JobStatesResponse) {
+func printJobStatesJSON(response *lib.JobStatesResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/sebrandon1/go-dci/lib"
@@ -57,10 +56,10 @@ var createJobCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printCreateJobJSON(response)
-		} else {
-			printCreateJobStdout(response)
+			return printCreateJobJSON(response)
 		}
+
+		printCreateJobStdout(response)
 
 		return nil
 	},
@@ -108,10 +107,10 @@ var updateJobStateCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printJobStateJSON(response)
-		} else {
-			printJobStateStdout(response)
+			return printJobStateJSON(response)
 		}
+
+		printJobStateStdout(response)
 
 		return nil
 	},
@@ -151,10 +150,10 @@ var uploadFileCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printUploadFileJSON(response)
-		} else {
-			printUploadFileStdout(response)
+			return printUploadFileJSON(response)
 		}
+
+		printUploadFileStdout(response)
 
 		return nil
 	},
@@ -170,12 +169,13 @@ func printCreateJobStdout(response *lib.CreateJobResponse) {
 	fmt.Printf("Created:   %s\n", response.Job.CreatedAt)
 }
 
-func printCreateJobJSON(response *lib.CreateJobResponse) {
+func printCreateJobJSON(response *lib.CreateJobResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printJobStateStdout(response *lib.JobStateResponse) {
@@ -190,12 +190,13 @@ func printJobStateStdout(response *lib.JobStateResponse) {
 	fmt.Printf("Created:     %s\n", response.JobState.CreatedAt)
 }
 
-func printJobStateJSON(response *lib.JobStateResponse) {
+func printJobStateJSON(response *lib.JobStateResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printUploadFileStdout(response *lib.UploadFileResponse) {
@@ -209,12 +210,13 @@ func printUploadFileStdout(response *lib.UploadFileResponse) {
 	fmt.Printf("Created:   %s\n", response.File.CreatedAt)
 }
 
-func printUploadFileJSON(response *lib.UploadFileResponse) {
+func printUploadFileJSON(response *lib.UploadFileResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -35,10 +34,10 @@ var getProductsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printProductsJSON(response)
-		} else {
-			printProductsStdout(response)
+			return printProductsJSON(response)
 		}
+
+		printProductsStdout(response)
 
 		return nil
 	},
@@ -69,10 +68,10 @@ var getProductCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printProductJSON(response)
-		} else {
-			printProductStdout(response)
+			return printProductJSON(response)
 		}
+
+		printProductStdout(response)
 
 		return nil
 	},
@@ -91,12 +90,13 @@ func printProductsStdout(response *lib.ProductsResponse) {
 	fmt.Printf("Total Products: %d\n", len(response.Products))
 }
 
-func printProductsJSON(response *lib.ProductsResponse) {
+func printProductsJSON(response *lib.ProductsResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printProductStdout(response *lib.ProductResponse) {
@@ -110,12 +110,13 @@ func printProductStdout(response *lib.ProductResponse) {
 	fmt.Printf("Updated:     %s\n", response.Product.UpdatedAt)
 }
 
-func printProductJSON(response *lib.ProductResponse) {
+func printProductJSON(response *lib.ProductResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -41,10 +40,10 @@ var getRemoteCIsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printRemoteCIsJSON(response)
-		} else {
-			printRemoteCIsStdout(response)
+			return printRemoteCIsJSON(response)
 		}
+
+		printRemoteCIsStdout(response)
 
 		return nil
 	},
@@ -75,10 +74,10 @@ var getRemoteCICmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printRemoteCIJSON(response)
-		} else {
-			printRemoteCIStdout(response)
+			return printRemoteCIJSON(response)
 		}
+
+		printRemoteCIStdout(response)
 
 		return nil
 	},
@@ -112,11 +111,11 @@ var createRemoteCICmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printRemoteCIJSON(response)
-		} else {
-			fmt.Println("Remote CI created successfully!")
-			printRemoteCIStdout(response)
+			return printRemoteCIJSON(response)
 		}
+
+		fmt.Println("Remote CI created successfully!")
+		printRemoteCIStdout(response)
 
 		return nil
 	},
@@ -155,11 +154,11 @@ var updateRemoteCICmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printRemoteCIJSON(response)
-		} else {
-			fmt.Println("Remote CI updated successfully!")
-			printRemoteCIStdout(response)
+			return printRemoteCIJSON(response)
 		}
+
+		fmt.Println("Remote CI updated successfully!")
+		printRemoteCIStdout(response)
 
 		return nil
 	},
@@ -214,12 +213,13 @@ func printRemoteCIsStdout(response *lib.RemoteCIsResponse) {
 	fmt.Printf("Total Remote CIs: %d\n", len(response.RemoteCIs))
 }
 
-func printRemoteCIsJSON(response *lib.RemoteCIsResponse) {
+func printRemoteCIsJSON(response *lib.RemoteCIsResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printRemoteCIStdout(response *lib.RemoteCIResponse) {
@@ -232,12 +232,13 @@ func printRemoteCIStdout(response *lib.RemoteCIResponse) {
 	fmt.Printf("Updated:  %s\n", response.RemoteCI.UpdatedAt)
 }
 
-func printRemoteCIJSON(response *lib.RemoteCIResponse) {
+func printRemoteCIJSON(response *lib.RemoteCIResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -40,10 +39,10 @@ var getTeamsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTeamsJSON(response)
-		} else {
-			printTeamsStdout(response)
+			return printTeamsJSON(response)
 		}
+
+		printTeamsStdout(response)
 
 		return nil
 	},
@@ -74,10 +73,10 @@ var getTeamCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTeamJSON(response)
-		} else {
-			printTeamStdout(response)
+			return printTeamJSON(response)
 		}
+
+		printTeamStdout(response)
 
 		return nil
 	},
@@ -108,11 +107,11 @@ var createTeamCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTeamJSON(response)
-		} else {
-			fmt.Println("Team created successfully!")
-			printTeamStdout(response)
+			return printTeamJSON(response)
 		}
+
+		fmt.Println("Team created successfully!")
+		printTeamStdout(response)
 
 		return nil
 	},
@@ -151,11 +150,11 @@ var updateTeamCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTeamJSON(response)
-		} else {
-			fmt.Println("Team updated successfully!")
-			printTeamStdout(response)
+			return printTeamJSON(response)
 		}
+
+		fmt.Println("Team updated successfully!")
+		printTeamStdout(response)
 
 		return nil
 	},
@@ -210,12 +209,13 @@ func printTeamsStdout(response *lib.TeamsResponse) {
 	fmt.Printf("Total Teams: %d\n", len(response.Teams))
 }
 
-func printTeamsJSON(response *lib.TeamsResponse) {
+func printTeamsJSON(response *lib.TeamsResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printTeamStdout(response *lib.TeamResponse) {
@@ -229,12 +229,13 @@ func printTeamStdout(response *lib.TeamResponse) {
 	fmt.Printf("Updated:   %s\n", response.Team.UpdatedAt)
 }
 
-func printTeamJSON(response *lib.TeamResponse) {
+func printTeamJSON(response *lib.TeamResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/sebrandon1/go-dci/lib"
@@ -46,10 +45,10 @@ var getTopicCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTopicJSON(response)
-		} else {
-			printTopicStdout(response)
+			return printTopicJSON(response)
 		}
+
+		printTopicStdout(response)
 
 		return nil
 	},
@@ -93,11 +92,11 @@ var createTopicCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTopicJSON(response)
-		} else {
-			fmt.Println("Topic created successfully!")
-			printTopicStdout(response)
+			return printTopicJSON(response)
 		}
+
+		fmt.Println("Topic created successfully!")
+		printTopicStdout(response)
 
 		return nil
 	},
@@ -133,11 +132,11 @@ var updateTopicCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printTopicJSON(response)
-		} else {
-			fmt.Println("Topic updated successfully!")
-			printTopicStdout(response)
+			return printTopicJSON(response)
 		}
+
+		fmt.Println("Topic updated successfully!")
+		printTopicStdout(response)
 
 		return nil
 	},
@@ -209,11 +208,11 @@ var getTopicComponentsCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printComponentsJSON(componentsResponses)
-		} else {
-			printComponentsStdout(componentsResponses)
-			fmt.Printf("Total Components: %d\n", totalComponents)
+			return printComponentsJSON(componentsResponses)
 		}
+
+		printComponentsStdout(componentsResponses)
+		fmt.Printf("Total Components: %d\n", totalComponents)
 
 		return nil
 	},
@@ -233,12 +232,13 @@ func printTopicStdout(response *lib.TopicResponse) {
 	fmt.Printf("Updated:       %s\n", response.Topic.UpdatedAt)
 }
 
-func printTopicJSON(response *lib.TopicResponse) {
+func printTopicJSON(response *lib.TopicResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
@@ -46,10 +45,10 @@ var getUsersCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printUsersJSON(response)
-		} else {
-			printUsersStdout(response)
+			return printUsersJSON(response)
 		}
+
+		printUsersStdout(response)
 
 		return nil
 	},
@@ -80,10 +79,10 @@ var getUserCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printUserJSON(response)
-		} else {
-			printUserStdout(response)
+			return printUserJSON(response)
 		}
+
+		printUserStdout(response)
 
 		return nil
 	},
@@ -129,11 +128,11 @@ var createUserCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printUserJSON(response)
-		} else {
-			fmt.Println("User created successfully!")
-			printUserStdout(response)
+			return printUserJSON(response)
 		}
+
+		fmt.Println("User created successfully!")
+		printUserStdout(response)
 
 		return nil
 	},
@@ -178,11 +177,11 @@ var updateUserCmd = &cobra.Command{
 		}
 
 		if outputFormat == OutputFormatJSON {
-			printUserJSON(response)
-		} else {
-			fmt.Println("User updated successfully!")
-			printUserStdout(response)
+			return printUserJSON(response)
 		}
+
+		fmt.Println("User updated successfully!")
+		printUserStdout(response)
 
 		return nil
 	},
@@ -237,12 +236,13 @@ func printUsersStdout(response *lib.UsersResponse) {
 	fmt.Printf("Total Users: %d\n", len(response.Users))
 }
 
-func printUsersJSON(response *lib.UsersResponse) {
+func printUsersJSON(response *lib.UsersResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func printUserStdout(response *lib.UserResponse) {
@@ -257,12 +257,13 @@ func printUserStdout(response *lib.UserResponse) {
 	fmt.Printf("Updated:  %s\n", response.User.UpdatedAt)
 }
 
-func printUserJSON(response *lib.UserResponse) {
+func printUserJSON(response *lib.UserResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 	fmt.Println(string(jsonBytes))
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- Convert all 22 JSON print helper functions across 11 cmd/ files from `log.Fatalf` (which calls `os.Exit(1)` bypassing Cobra) to returning `error`
- Call sites updated to propagate errors through RunE for consistent exit code handling
- Removed unused `log` import from all cmd/ files
- Zero `log.Fatalf` calls remain in the codebase

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `make test` -- all tests pass
- [x] `make lint` -- 0 issues
- [x] `grep -r log.Fatalf cmd/` returns nothing