### PR TITLE
feat: add context.Context support and retry with exponential backoff

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -43,7 +43,7 @@ var getComponentCmd = &cobra.Command{
 			fmt.Printf("Getting component with ID: %s\n", getComponentIDFlag)
 		}
 
-		response, err := client.GetComponent(getComponentIDFlag)
+		response, err := client.GetComponent(cmd.Context(), getComponentIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get component: %v", err)
 		}
@@ -85,7 +85,7 @@ var createComponentCmd = &cobra.Command{
 			fmt.Printf("Creating component: %s\n", createComponentName)
 		}
 
-		response, err := client.CreateComponent(createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
+		response, err := client.CreateComponent(cmd.Context(), createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
 		if err != nil {
 			return fmt.Errorf("failed to create component: %v", err)
 		}
@@ -138,7 +138,7 @@ var updateComponentCmd = &cobra.Command{
 			fmt.Printf("Updating component: %s\n", updateComponentIDFlag)
 		}
 
-		response, err := client.UpdateComponent(updateComponentIDFlag, updates)
+		response, err := client.UpdateComponent(cmd.Context(), updateComponentIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update component: %v", err)
 		}
@@ -173,7 +173,7 @@ var deleteComponentCmd = &cobra.Command{
 			fmt.Printf("Deleting component: %s\n", deleteComponentIDFlag)
 		}
 
-		err = client.DeleteComponent(deleteComponentIDFlag)
+		err = client.DeleteComponent(cmd.Context(), deleteComponentIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete component: %v", err)
 		}

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -37,7 +37,7 @@ var getComponentTypeCmd = &cobra.Command{
 			fmt.Printf("Getting component type with ID: %s\n", getComponentTypeIDFlag)
 		}
 
-		response, err := client.GetComponentType(getComponentTypeIDFlag)
+		response, err := client.GetComponentType(cmd.Context(), getComponentTypeIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get component type: %v", err)
 		}
@@ -71,7 +71,7 @@ var createComponentTypeCmd = &cobra.Command{
 			fmt.Printf("Creating component type: %s\n", createComponentTypeName)
 		}
 
-		response, err := client.CreateComponentType(createComponentTypeName)
+		response, err := client.CreateComponentType(cmd.Context(), createComponentTypeName)
 		if err != nil {
 			return fmt.Errorf("failed to create component type: %v", err)
 		}
@@ -114,7 +114,7 @@ var updateComponentTypeCmd = &cobra.Command{
 			fmt.Printf("Updating component type: %s\n", updateComponentTypeIDFlag)
 		}
 
-		response, err := client.UpdateComponentType(updateComponentTypeIDFlag, updates)
+		response, err := client.UpdateComponentType(cmd.Context(), updateComponentTypeIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update component type: %v", err)
 		}
@@ -149,7 +149,7 @@ var deleteComponentTypeCmd = &cobra.Command{
 			fmt.Printf("Deleting component type: %s\n", deleteComponentTypeIDFlag)
 		}
 
-		err = client.DeleteComponentType(deleteComponentTypeIDFlag)
+		err = client.DeleteComponentType(cmd.Context(), deleteComponentTypeIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete component type: %v", err)
 		}

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -35,7 +35,7 @@ var getFileCmd = &cobra.Command{
 			fmt.Printf("Downloading file with ID: %s\n", getFileIDFlag)
 		}
 
-		content, contentType, err := client.GetFile(getFileIDFlag)
+		content, contentType, err := client.GetFile(cmd.Context(), getFileIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get file: %v", err)
 		}
@@ -83,7 +83,7 @@ var deleteFileCmd = &cobra.Command{
 			fmt.Printf("Deleting file: %s\n", deleteFileIDFlag)
 		}
 
-		err = client.DeleteFile(deleteFileIDFlag)
+		err = client.DeleteFile(cmd.Context(), deleteFileIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete file: %v", err)
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -44,7 +44,7 @@ var getTopicsCmd = &cobra.Command{
 			fmt.Println("Getting all topics from DCI")
 		}
 
-		topicsResponses, err := client.GetTopics()
+		topicsResponses, err := client.GetTopics(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get topics: %v", err)
 		}
@@ -80,7 +80,7 @@ var getComponentTypesCmd = &cobra.Command{
 			fmt.Println("Getting all component types from DCI")
 		}
 
-		componentTypesResponses, err := client.GetComponentTypes()
+		componentTypesResponses, err := client.GetComponentTypes(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get component types: %v", err)
 		}
@@ -112,7 +112,7 @@ var getIdentityCmd = &cobra.Command{
 
 		client := lib.NewClient(accessKey, secretKey)
 
-		identity, err := client.GetIdentity()
+		identity, err := client.GetIdentity(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("authentication failed: %v", err)
 		}
@@ -151,7 +151,7 @@ var getOcpCountCmd = &cobra.Command{
 
 		client := lib.NewClient(accessKey, secretKey)
 
-		jobsResponses, err := client.GetJobs(daysBackLimit)
+		jobsResponses, err := client.GetJobs(cmd.Context(), daysBackLimit)
 		if err != nil {
 			return fmt.Errorf("getting jobs: %v", err)
 		}
@@ -185,12 +185,12 @@ var getComponentsCmd = &cobra.Command{
 			if outputFormat != OutputFormatJSON {
 				fmt.Printf("Getting components for topic ID: %s\n", topicID)
 			}
-			componentsResponses, err = client.GetComponentsByTopicID(topicID)
+			componentsResponses, err = client.GetComponentsByTopicID(cmd.Context(), topicID)
 		} else {
 			if outputFormat != OutputFormatJSON {
 				fmt.Println("Getting all components from DCI")
 			}
-			componentsResponses, err = client.GetComponents()
+			componentsResponses, err = client.GetComponents(cmd.Context())
 		}
 
 		if err != nil {
@@ -258,7 +258,7 @@ var getJobsCmd = &cobra.Command{
 				fmt.Printf("Getting all jobs from DCI between %s and %s\n", startDate, endDate)
 			}
 
-			jobsResponses, err = client.GetJobsByDate(parsedStart, parsedEnd)
+			jobsResponses, err = client.GetJobsByDate(cmd.Context(), parsedStart, parsedEnd)
 			if err != nil {
 				return fmt.Errorf("failed to get jobs: %v", err)
 			}
@@ -274,7 +274,7 @@ var getJobsCmd = &cobra.Command{
 				return fmt.Errorf("invalid age value '%s': %v", ageInDays, err)
 			}
 
-			jobsResponses, err = client.GetJobs(daysBackLimit)
+			jobsResponses, err = client.GetJobs(cmd.Context(), daysBackLimit)
 			if err != nil {
 				return fmt.Errorf("failed to get jobs: %v", err)
 			}

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -39,7 +39,7 @@ var getJobCmd = &cobra.Command{
 			fmt.Printf("Getting job with ID: %s\n", getJobIDFlag)
 		}
 
-		response, err := client.GetJob(getJobIDFlag)
+		response, err := client.GetJob(cmd.Context(), getJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job: %v", err)
 		}
@@ -85,7 +85,7 @@ var updateJobCmd = &cobra.Command{
 			fmt.Printf("Updating job: %s\n", updateJobIDFlag)
 		}
 
-		response, err := client.UpdateJob(updateJobIDFlag, updates)
+		response, err := client.UpdateJob(cmd.Context(), updateJobIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update job: %v", err)
 		}
@@ -120,7 +120,7 @@ var deleteJobCmd = &cobra.Command{
 			fmt.Printf("Deleting job: %s\n", deleteJobIDFlag)
 		}
 
-		err = client.DeleteJob(deleteJobIDFlag)
+		err = client.DeleteJob(cmd.Context(), deleteJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete job: %v", err)
 		}
@@ -156,7 +156,7 @@ var scheduleJobCmd = &cobra.Command{
 			fmt.Printf("Scheduling job for topic: %s\n", scheduleJobTopicID)
 		}
 
-		response, err := client.ScheduleJob(scheduleJobTopicID)
+		response, err := client.ScheduleJob(cmd.Context(), scheduleJobTopicID)
 		if err != nil {
 			return fmt.Errorf("failed to schedule job: %v", err)
 		}
@@ -191,7 +191,7 @@ var getJobFilesCmd = &cobra.Command{
 			fmt.Printf("Getting files for job ID: %s\n", jobFilesIDFlag)
 		}
 
-		response, err := client.GetJobFiles(jobFilesIDFlag)
+		response, err := client.GetJobFiles(cmd.Context(), jobFilesIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job files: %v", err)
 		}

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -32,7 +32,7 @@ var getJobStatesCmd = &cobra.Command{
 			}
 		}
 
-		response, err := client.GetJobStates(getJobStatesJobIDFlag)
+		response, err := client.GetJobStates(cmd.Context(), getJobStatesJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job states: %v", err)
 		}

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -50,7 +50,7 @@ var createJobCmd = &cobra.Command{
 			fmt.Printf("Creating job for topic ID: %s\n", createJobTopicID)
 		}
 
-		response, err := client.CreateJob(createJobTopicID, componentIDs, createJobComment)
+		response, err := client.CreateJob(cmd.Context(), createJobTopicID, componentIDs, createJobComment)
 		if err != nil {
 			return fmt.Errorf("failed to create job: %v", err)
 		}
@@ -101,7 +101,7 @@ var updateJobStateCmd = &cobra.Command{
 			fmt.Printf("Updating job %s to status: %s\n", updateJobStateJobID, updateJobStateStatus)
 		}
 
-		response, err := client.UpdateJobState(updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
+		response, err := client.UpdateJobState(cmd.Context(), updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
 		if err != nil {
 			return fmt.Errorf("failed to update job state: %v", err)
 		}
@@ -144,7 +144,7 @@ var uploadFileCmd = &cobra.Command{
 			fmt.Printf("Uploading file %s to job %s\n", uploadFilePath, uploadFileJobID)
 		}
 
-		response, err := client.UploadFile(uploadFileJobID, uploadFilePath, uploadFileMimeType)
+		response, err := client.UploadFile(cmd.Context(), uploadFileJobID, uploadFilePath, uploadFileMimeType)
 		if err != nil {
 			return fmt.Errorf("failed to upload file: %v", err)
 		}

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -28,7 +28,7 @@ var getProductsCmd = &cobra.Command{
 			fmt.Println("Getting products...")
 		}
 
-		response, err := client.GetProducts()
+		response, err := client.GetProducts(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get products: %v", err)
 		}
@@ -62,7 +62,7 @@ var getProductCmd = &cobra.Command{
 			fmt.Printf("Getting product with ID: %s\n", getProductIDFlag)
 		}
 
-		response, err := client.GetProduct(getProductIDFlag)
+		response, err := client.GetProduct(cmd.Context(), getProductIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get product: %v", err)
 		}

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -34,7 +34,7 @@ var getRemoteCIsCmd = &cobra.Command{
 			fmt.Println("Getting remote CIs...")
 		}
 
-		response, err := client.GetRemoteCIs()
+		response, err := client.GetRemoteCIs(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get remote CIs: %v", err)
 		}
@@ -68,7 +68,7 @@ var getRemoteCICmd = &cobra.Command{
 			fmt.Printf("Getting remote CI with ID: %s\n", getRemoteCIsCmd_IDFlag)
 		}
 
-		response, err := client.GetRemoteCI(getRemoteCIsCmd_IDFlag)
+		response, err := client.GetRemoteCI(cmd.Context(), getRemoteCIsCmd_IDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get remote CI: %v", err)
 		}
@@ -105,7 +105,7 @@ var createRemoteCICmd = &cobra.Command{
 			fmt.Printf("Creating remote CI: %s\n", createRemoteCINameFlag)
 		}
 
-		response, err := client.CreateRemoteCI(createRemoteCINameFlag, createRemoteCITeamIDFlag)
+		response, err := client.CreateRemoteCI(cmd.Context(), createRemoteCINameFlag, createRemoteCITeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to create remote CI: %v", err)
 		}
@@ -148,7 +148,7 @@ var updateRemoteCICmd = &cobra.Command{
 			fmt.Printf("Updating remote CI: %s\n", updateRemoteCIIDFlag)
 		}
 
-		response, err := client.UpdateRemoteCI(updateRemoteCIIDFlag, updates)
+		response, err := client.UpdateRemoteCI(cmd.Context(), updateRemoteCIIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update remote CI: %v", err)
 		}
@@ -183,7 +183,7 @@ var deleteRemoteCICmd = &cobra.Command{
 			fmt.Printf("Deleting remote CI: %s\n", deleteRemoteCIIDFlag)
 		}
 
-		err = client.DeleteRemoteCI(deleteRemoteCIIDFlag)
+		err = client.DeleteRemoteCI(cmd.Context(), deleteRemoteCIIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete remote CI: %v", err)
 		}

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -33,7 +33,7 @@ var getTeamsCmd = &cobra.Command{
 			fmt.Println("Getting teams...")
 		}
 
-		response, err := client.GetTeams()
+		response, err := client.GetTeams(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get teams: %v", err)
 		}
@@ -67,7 +67,7 @@ var getTeamCmd = &cobra.Command{
 			fmt.Printf("Getting team with ID: %s\n", getTeamIDFlag)
 		}
 
-		response, err := client.GetTeam(getTeamIDFlag)
+		response, err := client.GetTeam(cmd.Context(), getTeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get team: %v", err)
 		}
@@ -101,7 +101,7 @@ var createTeamCmd = &cobra.Command{
 			fmt.Printf("Creating team: %s\n", createTeamNameFlag)
 		}
 
-		response, err := client.CreateTeam(createTeamNameFlag)
+		response, err := client.CreateTeam(cmd.Context(), createTeamNameFlag)
 		if err != nil {
 			return fmt.Errorf("failed to create team: %v", err)
 		}
@@ -144,7 +144,7 @@ var updateTeamCmd = &cobra.Command{
 			fmt.Printf("Updating team: %s\n", updateTeamIDFlag)
 		}
 
-		response, err := client.UpdateTeam(updateTeamIDFlag, updates)
+		response, err := client.UpdateTeam(cmd.Context(), updateTeamIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update team: %v", err)
 		}
@@ -179,7 +179,7 @@ var deleteTeamCmd = &cobra.Command{
 			fmt.Printf("Deleting team: %s\n", deleteTeamIDFlag)
 		}
 
-		err = client.DeleteTeam(deleteTeamIDFlag)
+		err = client.DeleteTeam(cmd.Context(), deleteTeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete team: %v", err)
 		}

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -39,7 +39,7 @@ var getTopicCmd = &cobra.Command{
 			fmt.Printf("Getting topic with ID: %s\n", getTopicIDFlag)
 		}
 
-		response, err := client.GetTopic(getTopicIDFlag)
+		response, err := client.GetTopic(cmd.Context(), getTopicIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get topic: %v", err)
 		}
@@ -86,7 +86,7 @@ var createTopicCmd = &cobra.Command{
 			fmt.Printf("Creating topic: %s\n", createTopicName)
 		}
 
-		response, err := client.CreateTopic(createTopicName, createTopicProductID, componentTypes)
+		response, err := client.CreateTopic(cmd.Context(), createTopicName, createTopicProductID, componentTypes)
 		if err != nil {
 			return fmt.Errorf("failed to create topic: %v", err)
 		}
@@ -126,7 +126,7 @@ var updateTopicCmd = &cobra.Command{
 			fmt.Printf("Updating topic: %s\n", getTopicIDFlag)
 		}
 
-		response, err := client.UpdateTopic(getTopicIDFlag, updates)
+		response, err := client.UpdateTopic(cmd.Context(), getTopicIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update topic: %v", err)
 		}
@@ -161,7 +161,7 @@ var deleteTopicCmd = &cobra.Command{
 			fmt.Printf("Deleting topic: %s\n", deleteTopicIDFlag)
 		}
 
-		err = client.DeleteTopic(deleteTopicIDFlag)
+		err = client.DeleteTopic(cmd.Context(), deleteTopicIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete topic: %v", err)
 		}
@@ -197,7 +197,7 @@ var getTopicComponentsCmd = &cobra.Command{
 			fmt.Printf("Getting components for topic ID: %s\n", topicComponentsIDFlag)
 		}
 
-		componentsResponses, err := client.GetTopicComponents(topicComponentsIDFlag)
+		componentsResponses, err := client.GetTopicComponents(cmd.Context(), topicComponentsIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get topic components: %v", err)
 		}

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -39,7 +39,7 @@ var getUsersCmd = &cobra.Command{
 			fmt.Println("Getting users...")
 		}
 
-		response, err := client.GetUsers()
+		response, err := client.GetUsers(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get users: %v", err)
 		}
@@ -73,7 +73,7 @@ var getUserCmd = &cobra.Command{
 			fmt.Printf("Getting user with ID: %s\n", getUserIDFlag)
 		}
 
-		response, err := client.GetUser(getUserIDFlag)
+		response, err := client.GetUser(cmd.Context(), getUserIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get user: %v", err)
 		}
@@ -117,6 +117,7 @@ var createUserCmd = &cobra.Command{
 		}
 
 		response, err := client.CreateUser(
+			cmd.Context(),
 			createUserNameFlag,
 			createUserEmailFlag,
 			createUserFullnameFlag,
@@ -171,7 +172,7 @@ var updateUserCmd = &cobra.Command{
 			fmt.Printf("Updating user: %s\n", updateUserIDFlag)
 		}
 
-		response, err := client.UpdateUser(updateUserIDFlag, updates)
+		response, err := client.UpdateUser(cmd.Context(), updateUserIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update user: %v", err)
 		}
@@ -206,7 +207,7 @@ var deleteUserCmd = &cobra.Command{
 			fmt.Printf("Deleting user: %s\n", deleteUserIDFlag)
 		}
 
-		err = client.DeleteUser(deleteUserIDFlag)
+		err = client.DeleteUser(cmd.Context(), deleteUserIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete user: %v", err)
 		}

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -37,7 +38,7 @@ func main() {
 
 	// Step 3: Verify authentication by getting identity
 	fmt.Println("1. Verifying authentication...")
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	if err != nil {
 		log.Fatalf("Authentication failed: %v", err)
 	}
@@ -52,7 +53,7 @@ func main() {
 
 	// Step 4: List available topics
 	fmt.Println("2. Listing available topics...")
-	topicsResp, err := client.GetTopics()
+	topicsResp, err := client.GetTopics(context.Background())
 	if err != nil {
 		log.Fatalf("Failed to get topics: %v", err)
 	}
@@ -69,7 +70,7 @@ func main() {
 
 	// Step 5: List component types
 	fmt.Println("3. Listing component types...")
-	componentTypesResp, err := client.GetComponentTypes()
+	componentTypesResp, err := client.GetComponentTypes(context.Background())
 	if err != nil {
 		log.Printf("   Could not get component types: %v\n", err)
 	} else {
@@ -86,7 +87,7 @@ func main() {
 
 	// Step 6: Get recent jobs (last 7 days)
 	fmt.Println("4. Getting recent jobs (last 7 days)...")
-	jobsResp, err := client.GetJobs(7)
+	jobsResp, err := client.GetJobs(context.Background(), 7)
 	if err != nil {
 		log.Printf("   Could not get jobs: %v\n", err)
 	} else {
@@ -117,7 +118,7 @@ func main() {
 
 	// Step 7: Get products (if available)
 	fmt.Println("5. Listing products...")
-	products, err := client.GetProducts()
+	products, err := client.GetProducts(context.Background())
 	if err != nil {
 		log.Printf("   Could not get products: %v\n", err)
 	} else if len(products.Products) == 0 {

--- a/examples/certification-workflow/main.go
+++ b/examples/certification-workflow/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -51,7 +52,7 @@ func main() {
 
 	// Step 1: Verify authentication
 	fmt.Println("1. Verifying authentication...")
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	if err != nil {
 		log.Fatalf("Authentication failed: %v", err)
 	}
@@ -59,7 +60,7 @@ func main() {
 
 	// Step 2: Get topic information
 	fmt.Println("2. Getting topic information...")
-	topic, err := client.GetTopic(*topicID)
+	topic, err := client.GetTopic(context.Background(), *topicID)
 	if err != nil {
 		log.Fatalf("Failed to get topic: %v", err)
 	}
@@ -69,7 +70,7 @@ func main() {
 
 	// Step 3: Get available components for this topic
 	fmt.Println("3. Getting available components...")
-	componentsResp, err := client.GetTopicComponents(*topicID)
+	componentsResp, err := client.GetTopicComponents(context.Background(), *topicID)
 	if err != nil {
 		log.Fatalf("Failed to get components: %v", err)
 	}
@@ -96,7 +97,7 @@ func main() {
 
 	// Step 4: Create a new job
 	fmt.Println("4. Creating new certification job...")
-	job, err := client.CreateJob(*topicID, componentIDs, "Certification run via go-dci example")
+	job, err := client.CreateJob(context.Background(), *topicID, componentIDs, "Certification run via go-dci example")
 	if err != nil {
 		log.Fatalf("Failed to create job: %v", err)
 	}
@@ -107,7 +108,7 @@ func main() {
 
 	// Step 5: Update job state to pre-run
 	fmt.Println("5. Updating job state to 'pre-run'...")
-	_, err = client.UpdateJobState(jobID, lib.JobStatePreRun, "Starting pre-run checks")
+	_, err = client.UpdateJobState(context.Background(), jobID, lib.JobStatePreRun, "Starting pre-run checks")
 	if err != nil {
 		log.Fatalf("Failed to update job state: %v", err)
 	}
@@ -118,7 +119,7 @@ func main() {
 
 	// Step 6: Update job state to running
 	fmt.Println("6. Updating job state to 'running'...")
-	_, err = client.UpdateJobState(jobID, lib.JobStateRunning, "Running certification tests")
+	_, err = client.UpdateJobState(context.Background(), jobID, lib.JobStateRunning, "Running certification tests")
 	if err != nil {
 		log.Fatalf("Failed to update job state: %v", err)
 	}
@@ -127,7 +128,7 @@ func main() {
 	// Step 7: Upload test results (if provided)
 	if *resultsFile != "" {
 		fmt.Println("7. Uploading test results...")
-		uploadResp, err := client.UploadFile(jobID, *resultsFile, "application/junit")
+		uploadResp, err := client.UploadFile(context.Background(), jobID, *resultsFile, "application/junit")
 		if err != nil {
 			log.Printf("   Warning: Failed to upload file: %v\n", err)
 		} else {
@@ -144,7 +145,7 @@ func main() {
 
 	// Step 8: Update job state to success
 	fmt.Println("8. Updating job state to 'success'...")
-	_, err = client.UpdateJobState(jobID, lib.JobStateSuccess, "All certification tests passed")
+	_, err = client.UpdateJobState(context.Background(), jobID, lib.JobStateSuccess, "All certification tests passed")
 	if err != nil {
 		log.Fatalf("Failed to update job state: %v", err)
 	}
@@ -152,7 +153,7 @@ func main() {
 
 	// Step 9: Verify final job state
 	fmt.Println("9. Verifying final job state...")
-	finalJob, err := client.GetJob(jobID)
+	finalJob, err := client.GetJob(context.Background(), jobID)
 	if err != nil {
 		log.Fatalf("Failed to get job: %v", err)
 	}
@@ -163,7 +164,7 @@ func main() {
 
 	// Get job states history
 	fmt.Println("\n   State History:")
-	states, err := client.GetJobStates(jobID)
+	states, err := client.GetJobStates(context.Background(), jobID)
 	if err != nil {
 		log.Printf("   Could not get job states: %v\n", err)
 	} else {

--- a/examples/component-query/main.go
+++ b/examples/component-query/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -45,7 +46,7 @@ func main() {
 	fmt.Println("=== DCI Component Analysis ===")
 
 	// Verify authentication
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	if err != nil {
 		log.Fatalf("Authentication failed: %v", err)
 	}
@@ -55,7 +56,7 @@ func main() {
 	fmt.Println("1. Available Component Types")
 	fmt.Println("   " + strings.Repeat("-", 40))
 
-	componentTypesResp, err := client.GetComponentTypes()
+	componentTypesResp, err := client.GetComponentTypes(context.Background())
 	if err != nil {
 		log.Fatalf("Failed to get component types: %v", err)
 	}
@@ -77,7 +78,7 @@ func main() {
 	fmt.Println("2. Available Topics")
 	fmt.Println("   " + strings.Repeat("-", 40))
 
-	topicsResp, err := client.GetTopics()
+	topicsResp, err := client.GetTopics(context.Background())
 	if err != nil {
 		log.Fatalf("Failed to get topics: %v", err)
 	}
@@ -115,7 +116,7 @@ func main() {
 
 	// If topic ID is specified, only get components for that topic
 	if *topicID != "" {
-		componentsResp, err := client.GetTopicComponents(*topicID)
+		componentsResp, err := client.GetTopicComponents(context.Background(), *topicID)
 		if err != nil {
 			log.Fatalf("Failed to get components: %v", err)
 		}
@@ -148,7 +149,7 @@ func main() {
 		}
 	} else {
 		// Get all components
-		componentsResp, err := client.GetComponents()
+		componentsResp, err := client.GetComponents(context.Background())
 		if err != nil {
 			log.Fatalf("Failed to get components: %v", err)
 		}

--- a/lib/client.go
+++ b/lib/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,6 +37,7 @@ type Client struct {
 	AccessKey  string
 	SecretKey  string
 	httpClient *http.Client
+	MaxRetries int
 }
 
 func NewClient(accessKey, secretKey string) *Client {
@@ -44,44 +46,104 @@ func NewClient(accessKey, secretKey string) *Client {
 		AccessKey:  accessKey,
 		SecretKey:  secretKey,
 		httpClient: &http.Client{},
+		MaxRetries: 3,
 	}
 }
 
-// doRequest is the core HTTP method that all HTTP operations go through.
-// It creates a request, sets headers, computes payload hash, signs with AWS SigV4, and executes.
-func (c *Client) doRequest(method, reqURL string, body []byte, headers map[string]string) (*http.Response, error) {
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
+func isRetryable(method string, statusCode int) bool {
+	if statusCode < 500 {
+		return false
+	}
+	return method == http.MethodGet || method == http.MethodDelete
+}
+
+func (c *Client) retryBackoff(ctx context.Context, attempt int) error {
+	backoff := time.Duration(1<<uint(attempt)) * time.Second
+	jitter := backoff / 4
+	sleep := backoff + time.Duration(rand.Int64N(int64(2*jitter))) - jitter
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(sleep):
+		return nil
+	}
+}
+
+func (c *Client) doRequest(ctx context.Context, method, reqURL string, body []byte, headers map[string]string) (*http.Response, error) {
+	var lastErr error
+	var lastResp *http.Response
+
+	for attempt := range c.MaxRetries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var bodyReader io.Reader
+		if body != nil {
+			bodyReader = bytes.NewReader(body)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+
+		payloadHash := emptyStringSHA256
+		if body != nil {
+			hash := sha256.Sum256(body)
+			payloadHash = hex.EncodeToString(hash[:])
+		}
+
+		signer := signerv4.NewSigner()
+		creds := aws.Credentials{AccessKeyID: c.AccessKey, SecretAccessKey: c.SecretKey}
+		if err := signer.SignHTTP(ctx, creds, req, payloadHash, serviceName, awsRegion, time.Now()); err != nil {
+			return nil, err
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < c.MaxRetries-1 {
+				if err := c.retryBackoff(ctx, attempt); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, lastErr
+		}
+
+		if !isRetryable(method, resp.StatusCode) {
+			return resp, nil
+		}
+
+		lastResp = resp
+		if attempt < c.MaxRetries-1 {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+
+			if err := c.retryBackoff(ctx, attempt); err != nil {
+				return nil, err
+			}
+			continue
+		}
 	}
 
-	req, err := http.NewRequest(method, reqURL, bodyReader)
-	if err != nil {
-		return nil, err
+	// Exhausted all retries — return last response or error
+	if lastResp != nil {
+		return lastResp, nil
 	}
 
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	payloadHash := emptyStringSHA256
-	if body != nil {
-		hash := sha256.Sum256(body)
-		payloadHash = hex.EncodeToString(hash[:])
-	}
-
-	signer := signerv4.NewSigner()
-	creds := aws.Credentials{AccessKeyID: c.AccessKey, SecretAccessKey: c.SecretKey}
-	if err := signer.SignHTTP(context.Background(), creds, req, payloadHash, serviceName, awsRegion, time.Now()); err != nil {
-		return nil, err
-	}
-
-	return c.httpClient.Do(req)
+	return nil, lastErr
 }
 
 // doJSON is a convenience method for POST/PUT requests with a JSON body.
-func (c *Client) doJSON(method, reqURL string, jsonBody []byte) (*http.Response, error) {
-	return c.doRequest(method, reqURL, jsonBody, map[string]string{"Content-Type": "application/json"})
+func (c *Client) doJSON(ctx context.Context, method, reqURL string, jsonBody []byte) (*http.Response, error) {
+	return c.doRequest(ctx, method, reqURL, jsonBody, map[string]string{"Content-Type": "application/json"})
 }
 
 // paginatedURL builds a URL with limit, offset, sort, and optional where filters.
@@ -108,11 +170,15 @@ func paginatedURL(base string, limit, offset int, filters ...string) string {
 }
 
 // paginate is a generic helper that handles the standard pagination loop.
-func paginate[T any](fetch func(limit, offset int) (T, int, error)) ([]T, error) {
+func paginate[T any](ctx context.Context, fetch func(limit, offset int) (T, int, error)) ([]T, error) {
 	var collection []T
 	offset := 0
 
 	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		page, count, err := fetch(defaultPageSize, offset)
 		if err != nil {
 			return nil, err
@@ -135,8 +201,8 @@ func paginate[T any](fetch func(limit, offset int) (T, int, error)) ([]T, error)
 }
 
 // GetIdentity retrieves the authenticated user/remoteci identity from the DCI API
-func (c *Client) GetIdentity() (*IdentityResponse, error) {
-	httpResponse, err := c.doRequest("GET", c.BaseURL+"/identity", nil, nil)
+func (c *Client) GetIdentity(ctx context.Context) (*IdentityResponse, error) {
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, c.BaseURL+"/identity", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,16 +223,16 @@ func (c *Client) GetIdentity() (*IdentityResponse, error) {
 }
 
 // GetComponentTypes retrieves all component types from the DCI API with pagination
-func (c *Client) GetComponentTypes() ([]ComponentTypesResponse, error) {
-	return paginate(func(limit, offset int) (ComponentTypesResponse, int, error) {
-		resp, err := c.fetchComponentTypes(limit, offset)
+func (c *Client) GetComponentTypes(ctx context.Context) ([]ComponentTypesResponse, error) {
+	return paginate(ctx, func(limit, offset int) (ComponentTypesResponse, int, error) {
+		resp, err := c.fetchComponentTypes(ctx, limit, offset)
 		return resp, len(resp.ComponentTypes), err
 	})
 }
 
 // fetchComponentTypes is an internal helper to fetch component types with pagination
-func (c *Client) fetchComponentTypes(requestLimit, offset int) (ComponentTypesResponse, error) {
-	httpResponse, err := c.doRequest("GET", paginatedURL(c.BaseURL+"/componenttypes", requestLimit, offset), nil, nil)
+func (c *Client) fetchComponentTypes(ctx context.Context, requestLimit, offset int) (ComponentTypesResponse, error) {
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, paginatedURL(c.BaseURL+"/componenttypes", requestLimit, offset), nil, nil)
 	if err != nil {
 		return ComponentTypesResponse{}, err
 	}
@@ -183,9 +249,9 @@ func (c *Client) fetchComponentTypes(requestLimit, offset int) (ComponentTypesRe
 }
 
 // GetComponentType retrieves a single component type by ID from the DCI API
-func (c *Client) GetComponentType(componentTypeID string) (*ComponentTypeResponse, error) {
+func (c *Client) GetComponentType(ctx context.Context, componentTypeID string) (*ComponentTypeResponse, error) {
 	reqURL := fmt.Sprintf("%s/componenttypes/%s", c.BaseURL, componentTypeID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting component type: %w", err)
 	}
@@ -206,7 +272,7 @@ func (c *Client) GetComponentType(componentTypeID string) (*ComponentTypeRespons
 }
 
 // CreateComponentType creates a new component type in DCI
-func (c *Client) CreateComponentType(name string) (*ComponentTypeResponse, error) {
+func (c *Client) CreateComponentType(ctx context.Context, name string) (*ComponentTypeResponse, error) {
 	reqBody := CreateComponentTypeRequest{
 		Name: name,
 	}
@@ -217,7 +283,7 @@ func (c *Client) CreateComponentType(name string) (*ComponentTypeResponse, error
 	}
 
 	reqURL := fmt.Sprintf("%s/componenttypes", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating component type: %w", err)
 	}
@@ -238,14 +304,14 @@ func (c *Client) CreateComponentType(name string) (*ComponentTypeResponse, error
 }
 
 // UpdateComponentType updates an existing component type in DCI
-func (c *Client) UpdateComponentType(componentTypeID string, updates UpdateComponentTypeRequest) (*ComponentTypeResponse, error) {
+func (c *Client) UpdateComponentType(ctx context.Context, componentTypeID string, updates UpdateComponentTypeRequest) (*ComponentTypeResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/componenttypes/%s", c.BaseURL, componentTypeID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating component type: %w", err)
 	}
@@ -266,9 +332,9 @@ func (c *Client) UpdateComponentType(componentTypeID string, updates UpdateCompo
 }
 
 // DeleteComponentType deletes a component type from DCI
-func (c *Client) DeleteComponentType(componentTypeID string) error {
+func (c *Client) DeleteComponentType(ctx context.Context, componentTypeID string) error {
 	reqURL := fmt.Sprintf("%s/componenttypes/%s", c.BaseURL, componentTypeID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting component type: %w", err)
 	}
@@ -283,16 +349,16 @@ func (c *Client) DeleteComponentType(componentTypeID string) error {
 	return nil
 }
 
-func (c *Client) GetTopics() ([]TopicsResponse, error) {
-	return paginate(func(limit, offset int) (TopicsResponse, int, error) {
-		resp, err := c.fetchTopics(limit, offset)
+func (c *Client) GetTopics(ctx context.Context) ([]TopicsResponse, error) {
+	return paginate(ctx, func(limit, offset int) (TopicsResponse, int, error) {
+		resp, err := c.fetchTopics(ctx, limit, offset)
 		return resp, len(resp.Topics), err
 	})
 }
 
 // fetchTopics is an internal helper to fetch topics with pagination
-func (c *Client) fetchTopics(requestLimit, offset int) (TopicsResponse, error) {
-	httpResponse, err := c.doRequest("GET", paginatedURL(c.BaseURL+"/topics", requestLimit, offset), nil, nil)
+func (c *Client) fetchTopics(ctx context.Context, requestLimit, offset int) (TopicsResponse, error) {
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, paginatedURL(c.BaseURL+"/topics", requestLimit, offset), nil, nil)
 	if err != nil {
 		return TopicsResponse{}, err
 	}
@@ -309,9 +375,9 @@ func (c *Client) fetchTopics(requestLimit, offset int) (TopicsResponse, error) {
 }
 
 // GetTopic retrieves a single topic by ID from the DCI API
-func (c *Client) GetTopic(topicID string) (*TopicResponse, error) {
+func (c *Client) GetTopic(ctx context.Context, topicID string) (*TopicResponse, error) {
 	reqURL := fmt.Sprintf("%s/topics/%s", c.BaseURL, topicID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting topic: %w", err)
 	}
@@ -332,7 +398,7 @@ func (c *Client) GetTopic(topicID string) (*TopicResponse, error) {
 }
 
 // CreateTopic creates a new topic in DCI
-func (c *Client) CreateTopic(name, productID string, componentTypes []string) (*TopicResponse, error) {
+func (c *Client) CreateTopic(ctx context.Context, name, productID string, componentTypes []string) (*TopicResponse, error) {
 	reqBody := CreateTopicRequest{
 		Name:           name,
 		ProductID:      productID,
@@ -344,7 +410,7 @@ func (c *Client) CreateTopic(name, productID string, componentTypes []string) (*
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
-	httpResponse, err := c.doJSON("POST", c.BaseURL+"/topics", jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, c.BaseURL+"/topics", jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating topic: %w", err)
 	}
@@ -365,14 +431,14 @@ func (c *Client) CreateTopic(name, productID string, componentTypes []string) (*
 }
 
 // UpdateTopic updates an existing topic in DCI
-func (c *Client) UpdateTopic(topicID string, updates UpdateTopicRequest) (*TopicResponse, error) {
+func (c *Client) UpdateTopic(ctx context.Context, topicID string, updates UpdateTopicRequest) (*TopicResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/topics/%s", c.BaseURL, topicID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating topic: %w", err)
 	}
@@ -393,9 +459,9 @@ func (c *Client) UpdateTopic(topicID string, updates UpdateTopicRequest) (*Topic
 }
 
 // DeleteTopic deletes a topic from DCI
-func (c *Client) DeleteTopic(topicID string) error {
+func (c *Client) DeleteTopic(ctx context.Context, topicID string) error {
 	reqURL := fmt.Sprintf("%s/topics/%s", c.BaseURL, topicID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting topic: %w", err)
 	}
@@ -411,17 +477,17 @@ func (c *Client) DeleteTopic(topicID string) error {
 }
 
 // GetTopicComponents retrieves all components for a specific topic using the topic components endpoint
-func (c *Client) GetTopicComponents(topicID string) ([]ComponentsResponse, error) {
-	return paginate(func(limit, offset int) (ComponentsResponse, int, error) {
-		resp, err := c.fetchTopicComponents(topicID, limit, offset)
+func (c *Client) GetTopicComponents(ctx context.Context, topicID string) ([]ComponentsResponse, error) {
+	return paginate(ctx, func(limit, offset int) (ComponentsResponse, int, error) {
+		resp, err := c.fetchTopicComponents(ctx, topicID, limit, offset)
 		return resp, len(resp.Components), err
 	})
 }
 
 // fetchTopicComponents is an internal helper to fetch components for a topic with pagination
-func (c *Client) fetchTopicComponents(topicID string, requestLimit, offset int) (ComponentsResponse, error) {
+func (c *Client) fetchTopicComponents(ctx context.Context, topicID string, requestLimit, offset int) (ComponentsResponse, error) {
 	reqURL := paginatedURL(fmt.Sprintf("%s/topics/%s/components", c.BaseURL, topicID), requestLimit, offset)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return ComponentsResponse{}, fmt.Errorf("error getting topic components: %w", err)
 	}
@@ -436,7 +502,7 @@ func (c *Client) fetchTopicComponents(topicID string, requestLimit, offset int) 
 	return components, nil
 }
 
-func (c *Client) GetJobs(daysBackLimit int) ([]JobsResponse, error) {
+func (c *Client) GetJobs(ctx context.Context, daysBackLimit int) ([]JobsResponse, error) {
 	var jobCollection []JobsResponse
 
 	// Default values to page through the results
@@ -444,9 +510,13 @@ func (c *Client) GetJobs(daysBackLimit int) ([]JobsResponse, error) {
 	offset := 0
 
 	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
 		outOfDateRangeJobReturned := false
 
-		jobs, err := c.fetchJobs(requestLimit, offset)
+		jobs, err := c.fetchJobs(ctx, requestLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -490,7 +560,7 @@ func (c *Client) GetJobs(daysBackLimit int) ([]JobsResponse, error) {
 	return jobCollection, nil
 }
 
-func (c *Client) GetJobsByDate(startDate, endDate time.Time) ([]JobsResponse, error) {
+func (c *Client) GetJobsByDate(ctx context.Context, startDate, endDate time.Time) ([]JobsResponse, error) {
 	var jobCollection []JobsResponse
 
 	// Default values to page through the results
@@ -498,7 +568,11 @@ func (c *Client) GetJobsByDate(startDate, endDate time.Time) ([]JobsResponse, er
 	offset := 0
 
 	for {
-		jobs, err := c.fetchJobs(requestLimit, offset)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		jobs, err := c.fetchJobs(ctx, requestLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -535,9 +609,9 @@ func (c *Client) GetJobsByDate(startDate, endDate time.Time) ([]JobsResponse, er
 }
 
 // GetJob retrieves a single job by ID from the DCI API
-func (c *Client) GetJob(jobID string) (*JobResponse, error) {
+func (c *Client) GetJob(ctx context.Context, jobID string) (*JobResponse, error) {
 	reqURL := fmt.Sprintf("%s/jobs/%s", c.BaseURL, jobID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting job: %w", err)
 	}
@@ -558,14 +632,14 @@ func (c *Client) GetJob(jobID string) (*JobResponse, error) {
 }
 
 // UpdateJob updates an existing job in DCI
-func (c *Client) UpdateJob(jobID string, updates UpdateJobRequest) (*JobResponse, error) {
+func (c *Client) UpdateJob(ctx context.Context, jobID string, updates UpdateJobRequest) (*JobResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/jobs/%s", c.BaseURL, jobID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating job: %w", err)
 	}
@@ -586,9 +660,9 @@ func (c *Client) UpdateJob(jobID string, updates UpdateJobRequest) (*JobResponse
 }
 
 // DeleteJob deletes a job from DCI
-func (c *Client) DeleteJob(jobID string) error {
+func (c *Client) DeleteJob(ctx context.Context, jobID string) error {
 	reqURL := fmt.Sprintf("%s/jobs/%s", c.BaseURL, jobID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting job: %w", err)
 	}
@@ -604,7 +678,7 @@ func (c *Client) DeleteJob(jobID string) error {
 }
 
 // ScheduleJob schedules a job with auto-selected components for a topic
-func (c *Client) ScheduleJob(topicID string) (*CreateJobResponse, error) {
+func (c *Client) ScheduleJob(ctx context.Context, topicID string) (*CreateJobResponse, error) {
 	reqBody := ScheduleJobRequest{
 		TopicID: topicID,
 	}
@@ -615,7 +689,7 @@ func (c *Client) ScheduleJob(topicID string) (*CreateJobResponse, error) {
 	}
 
 	reqURL := fmt.Sprintf("%s/jobs/schedule", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error scheduling job: %w", err)
 	}
@@ -636,9 +710,9 @@ func (c *Client) ScheduleJob(topicID string) (*CreateJobResponse, error) {
 }
 
 // GetJobFiles retrieves all files for a specific job
-func (c *Client) GetJobFiles(jobID string) (*FilesResponse, error) {
+func (c *Client) GetJobFiles(ctx context.Context, jobID string) (*FilesResponse, error) {
 	reqURL := fmt.Sprintf("%s/jobs/%s/files", c.BaseURL, jobID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting job files: %w", err)
 	}
@@ -658,9 +732,9 @@ func (c *Client) GetJobFiles(jobID string) (*FilesResponse, error) {
 	return &response, nil
 }
 
-func (c *Client) fetchJobs(requestLimit, offset int) (JobsResponse, error) {
+func (c *Client) fetchJobs(ctx context.Context, requestLimit, offset int) (JobsResponse, error) {
 	// Get jobs from the API
-	httpResponse, err := c.doRequest("GET", paginatedURL(c.BaseURL+"/jobs", requestLimit, offset), nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, paginatedURL(c.BaseURL+"/jobs", requestLimit, offset), nil, nil)
 	if err != nil {
 		return JobsResponse{}, err
 	}
@@ -678,22 +752,22 @@ func (c *Client) fetchJobs(requestLimit, offset int) (JobsResponse, error) {
 }
 
 // GetComponents retrieves all components from the DCI API with pagination
-func (c *Client) GetComponents() ([]ComponentsResponse, error) {
-	return c.GetComponentsByTopicID("")
+func (c *Client) GetComponents(ctx context.Context) ([]ComponentsResponse, error) {
+	return c.GetComponentsByTopicID(ctx, "")
 }
 
 // GetComponentsByTopicID retrieves components filtered by topic ID (empty string for all)
-func (c *Client) GetComponentsByTopicID(topicID string) ([]ComponentsResponse, error) {
-	return paginate(func(limit, offset int) (ComponentsResponse, int, error) {
-		resp, err := c.fetchComponents(topicID, limit, offset)
+func (c *Client) GetComponentsByTopicID(ctx context.Context, topicID string) ([]ComponentsResponse, error) {
+	return paginate(ctx, func(limit, offset int) (ComponentsResponse, int, error) {
+		resp, err := c.fetchComponents(ctx, topicID, limit, offset)
 		return resp, len(resp.Components), err
 	})
 }
 
 // GetComponent retrieves a single component by ID from the DCI API
-func (c *Client) GetComponent(componentID string) (*ComponentResponse, error) {
+func (c *Client) GetComponent(ctx context.Context, componentID string) (*ComponentResponse, error) {
 	reqURL := fmt.Sprintf("%s/components/%s", c.BaseURL, componentID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting component: %w", err)
 	}
@@ -714,7 +788,7 @@ func (c *Client) GetComponent(componentID string) (*ComponentResponse, error) {
 }
 
 // CreateComponent creates a new component in DCI
-func (c *Client) CreateComponent(name, componentType, topicID, version string) (*ComponentResponse, error) {
+func (c *Client) CreateComponent(ctx context.Context, name, componentType, topicID, version string) (*ComponentResponse, error) {
 	reqBody := CreateComponentRequest{
 		Name:    name,
 		Type:    componentType,
@@ -728,7 +802,7 @@ func (c *Client) CreateComponent(name, componentType, topicID, version string) (
 	}
 
 	reqURL := fmt.Sprintf("%s/components", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating component: %w", err)
 	}
@@ -749,14 +823,14 @@ func (c *Client) CreateComponent(name, componentType, topicID, version string) (
 }
 
 // UpdateComponent updates an existing component in DCI
-func (c *Client) UpdateComponent(componentID string, updates UpdateComponentRequest) (*ComponentResponse, error) {
+func (c *Client) UpdateComponent(ctx context.Context, componentID string, updates UpdateComponentRequest) (*ComponentResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/components/%s", c.BaseURL, componentID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating component: %w", err)
 	}
@@ -777,9 +851,9 @@ func (c *Client) UpdateComponent(componentID string, updates UpdateComponentRequ
 }
 
 // DeleteComponent deletes a component from DCI
-func (c *Client) DeleteComponent(componentID string) error {
+func (c *Client) DeleteComponent(ctx context.Context, componentID string) error {
 	reqURL := fmt.Sprintf("%s/components/%s", c.BaseURL, componentID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting component: %w", err)
 	}
@@ -795,14 +869,14 @@ func (c *Client) DeleteComponent(componentID string) error {
 }
 
 // fetchComponents is an internal helper to fetch components with optional topic filtering
-func (c *Client) fetchComponents(topicID string, requestLimit, offset int) (ComponentsResponse, error) {
+func (c *Client) fetchComponents(ctx context.Context, topicID string, requestLimit, offset int) (ComponentsResponse, error) {
 	var filter string
 	if topicID != "" {
 		filter = "topic_id:" + topicID
 	}
 
 	reqURL := paginatedURL(c.BaseURL+"/components", requestLimit, offset, filter)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return ComponentsResponse{}, err
 	}
@@ -819,7 +893,7 @@ func (c *Client) fetchComponents(topicID string, requestLimit, offset int) (Comp
 }
 
 // CreateJob creates a new job in DCI
-func (c *Client) CreateJob(topicID string, componentIDs []string, comment string) (*CreateJobResponse, error) {
+func (c *Client) CreateJob(ctx context.Context, topicID string, componentIDs []string, comment string) (*CreateJobResponse, error) {
 	reqBody := CreateJobRequest{
 		TopicID:    topicID,
 		Components: componentIDs,
@@ -831,7 +905,7 @@ func (c *Client) CreateJob(topicID string, componentIDs []string, comment string
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
-	httpResponse, err := c.doJSON("POST", c.BaseURL+"/jobs", jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, c.BaseURL+"/jobs", jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating job: %w", err)
 	}
@@ -852,7 +926,7 @@ func (c *Client) CreateJob(topicID string, componentIDs []string, comment string
 }
 
 // UpdateJobState updates the state of a job (pre-run, running, success, failure, etc.)
-func (c *Client) UpdateJobState(jobID string, status JobState, comment string) (*JobStateResponse, error) {
+func (c *Client) UpdateJobState(ctx context.Context, jobID string, status JobState, comment string) (*JobStateResponse, error) {
 	reqBody := UpdateJobStateRequest{
 		JobID:   jobID,
 		Status:  string(status),
@@ -865,7 +939,7 @@ func (c *Client) UpdateJobState(jobID string, status JobState, comment string) (
 	}
 
 	reqURL := fmt.Sprintf("%s/jobstates", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating job state: %w", err)
 	}
@@ -886,13 +960,13 @@ func (c *Client) UpdateJobState(jobID string, status JobState, comment string) (
 }
 
 // GetJobStates retrieves job states, optionally filtered by job ID
-func (c *Client) GetJobStates(jobID string) (*JobStatesResponse, error) {
+func (c *Client) GetJobStates(ctx context.Context, jobID string) (*JobStatesResponse, error) {
 	reqURL := fmt.Sprintf("%s/jobstates", c.BaseURL)
 	if jobID != "" {
 		reqURL = fmt.Sprintf("%s?where=job_id:%s", reqURL, jobID)
 	}
 
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting job states: %w", err)
 	}
@@ -913,9 +987,9 @@ func (c *Client) GetJobStates(jobID string) (*JobStatesResponse, error) {
 }
 
 // GetFile downloads a file by ID from DCI
-func (c *Client) GetFile(fileID string) ([]byte, string, error) {
+func (c *Client) GetFile(ctx context.Context, fileID string) ([]byte, string, error) {
 	reqURL := fmt.Sprintf("%s/files/%s", c.BaseURL, fileID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("error getting file: %w", err)
 	}
@@ -937,9 +1011,9 @@ func (c *Client) GetFile(fileID string) ([]byte, string, error) {
 }
 
 // DeleteFile deletes a file from DCI
-func (c *Client) DeleteFile(fileID string) error {
+func (c *Client) DeleteFile(ctx context.Context, fileID string) error {
 	reqURL := fmt.Sprintf("%s/files/%s", c.BaseURL, fileID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting file: %w", err)
 	}
@@ -955,7 +1029,7 @@ func (c *Client) DeleteFile(fileID string) error {
 }
 
 // UploadFile uploads a file (e.g., test results) to a job in DCI
-func (c *Client) UploadFile(jobID, filePath, mimeType string) (*UploadFileResponse, error) {
+func (c *Client) UploadFile(ctx context.Context, jobID, filePath, mimeType string) (*UploadFileResponse, error) {
 	// Read the file
 	fileContent, err := os.ReadFile(filePath)
 	if err != nil {
@@ -964,16 +1038,16 @@ func (c *Client) UploadFile(jobID, filePath, mimeType string) (*UploadFileRespon
 
 	fileName := filepath.Base(filePath)
 
-	return c.uploadFileContent(c.BaseURL+"/files", fileContent, jobID, fileName, mimeType)
+	return c.uploadFileContent(ctx, c.BaseURL+"/files", fileContent, jobID, fileName, mimeType)
 }
 
 // UploadFileContent uploads file content directly (without reading from disk) to a job in DCI
-func (c *Client) UploadFileContent(jobID, fileName, mimeType string, content []byte) (*UploadFileResponse, error) {
-	return c.uploadFileContent(c.BaseURL+"/files", content, jobID, fileName, mimeType)
+func (c *Client) UploadFileContent(ctx context.Context, jobID, fileName, mimeType string, content []byte) (*UploadFileResponse, error) {
+	return c.uploadFileContent(ctx, c.BaseURL+"/files", content, jobID, fileName, mimeType)
 }
 
 // uploadFileContent is the shared implementation for file uploads
-func (c *Client) uploadFileContent(reqURL string, content []byte, jobID, fileName, mimeType string) (*UploadFileResponse, error) {
+func (c *Client) uploadFileContent(ctx context.Context, reqURL string, content []byte, jobID, fileName, mimeType string) (*UploadFileResponse, error) {
 	headers := map[string]string{
 		"DCI-JOB-ID":    jobID,
 		"DCI-NAME":      fileName,
@@ -981,7 +1055,7 @@ func (c *Client) uploadFileContent(reqURL string, content []byte, jobID, fileNam
 		"Content-Type":  "application/octet-stream",
 	}
 
-	httpResponse, err := c.doRequest("POST", reqURL, content, headers)
+	httpResponse, err := c.doRequest(ctx, http.MethodPost, reqURL, content, headers)
 	if err != nil {
 		return nil, fmt.Errorf("error uploading file: %w", err)
 	}
@@ -1002,9 +1076,9 @@ func (c *Client) uploadFileContent(reqURL string, content []byte, jobID, fileNam
 }
 
 // GetRemoteCIs retrieves all remote CIs from DCI
-func (c *Client) GetRemoteCIs() (*RemoteCIsResponse, error) {
+func (c *Client) GetRemoteCIs(ctx context.Context) (*RemoteCIsResponse, error) {
 	reqURL := fmt.Sprintf("%s/remotecis", c.BaseURL)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting remote CIs: %w", err)
 	}
@@ -1025,9 +1099,9 @@ func (c *Client) GetRemoteCIs() (*RemoteCIsResponse, error) {
 }
 
 // GetRemoteCI retrieves a specific remote CI by ID
-func (c *Client) GetRemoteCI(remoteciID string) (*RemoteCIResponse, error) {
+func (c *Client) GetRemoteCI(ctx context.Context, remoteciID string) (*RemoteCIResponse, error) {
 	reqURL := fmt.Sprintf("%s/remotecis/%s", c.BaseURL, remoteciID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting remote CI: %w", err)
 	}
@@ -1048,7 +1122,7 @@ func (c *Client) GetRemoteCI(remoteciID string) (*RemoteCIResponse, error) {
 }
 
 // CreateRemoteCI creates a new remote CI in DCI
-func (c *Client) CreateRemoteCI(name, teamID string) (*RemoteCIResponse, error) {
+func (c *Client) CreateRemoteCI(ctx context.Context, name, teamID string) (*RemoteCIResponse, error) {
 	reqBody := CreateRemoteCIRequest{
 		Name:   name,
 		TeamID: teamID,
@@ -1060,7 +1134,7 @@ func (c *Client) CreateRemoteCI(name, teamID string) (*RemoteCIResponse, error) 
 	}
 
 	reqURL := fmt.Sprintf("%s/remotecis", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating remote CI: %w", err)
 	}
@@ -1081,14 +1155,14 @@ func (c *Client) CreateRemoteCI(name, teamID string) (*RemoteCIResponse, error) 
 }
 
 // UpdateRemoteCI updates an existing remote CI in DCI
-func (c *Client) UpdateRemoteCI(remoteciID string, updates UpdateRemoteCIRequest) (*RemoteCIResponse, error) {
+func (c *Client) UpdateRemoteCI(ctx context.Context, remoteciID string, updates UpdateRemoteCIRequest) (*RemoteCIResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/remotecis/%s", c.BaseURL, remoteciID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating remote CI: %w", err)
 	}
@@ -1109,9 +1183,9 @@ func (c *Client) UpdateRemoteCI(remoteciID string, updates UpdateRemoteCIRequest
 }
 
 // DeleteRemoteCI deletes a remote CI from DCI
-func (c *Client) DeleteRemoteCI(remoteciID string) error {
+func (c *Client) DeleteRemoteCI(ctx context.Context, remoteciID string) error {
 	reqURL := fmt.Sprintf("%s/remotecis/%s", c.BaseURL, remoteciID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting remote CI: %w", err)
 	}
@@ -1127,9 +1201,9 @@ func (c *Client) DeleteRemoteCI(remoteciID string) error {
 }
 
 // GetTeams retrieves all teams from DCI
-func (c *Client) GetTeams() (*TeamsResponse, error) {
+func (c *Client) GetTeams(ctx context.Context) (*TeamsResponse, error) {
 	reqURL := fmt.Sprintf("%s/teams", c.BaseURL)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting teams: %w", err)
 	}
@@ -1150,9 +1224,9 @@ func (c *Client) GetTeams() (*TeamsResponse, error) {
 }
 
 // GetTeam retrieves a specific team by ID
-func (c *Client) GetTeam(teamID string) (*TeamResponse, error) {
+func (c *Client) GetTeam(ctx context.Context, teamID string) (*TeamResponse, error) {
 	reqURL := fmt.Sprintf("%s/teams/%s", c.BaseURL, teamID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting team: %w", err)
 	}
@@ -1173,7 +1247,7 @@ func (c *Client) GetTeam(teamID string) (*TeamResponse, error) {
 }
 
 // CreateTeam creates a new team in DCI
-func (c *Client) CreateTeam(name string) (*TeamResponse, error) {
+func (c *Client) CreateTeam(ctx context.Context, name string) (*TeamResponse, error) {
 	reqBody := CreateTeamRequest{
 		Name: name,
 	}
@@ -1184,7 +1258,7 @@ func (c *Client) CreateTeam(name string) (*TeamResponse, error) {
 	}
 
 	reqURL := fmt.Sprintf("%s/teams", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating team: %w", err)
 	}
@@ -1205,14 +1279,14 @@ func (c *Client) CreateTeam(name string) (*TeamResponse, error) {
 }
 
 // UpdateTeam updates an existing team in DCI
-func (c *Client) UpdateTeam(teamID string, updates UpdateTeamRequest) (*TeamResponse, error) {
+func (c *Client) UpdateTeam(ctx context.Context, teamID string, updates UpdateTeamRequest) (*TeamResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/teams/%s", c.BaseURL, teamID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating team: %w", err)
 	}
@@ -1233,9 +1307,9 @@ func (c *Client) UpdateTeam(teamID string, updates UpdateTeamRequest) (*TeamResp
 }
 
 // DeleteTeam deletes a team from DCI
-func (c *Client) DeleteTeam(teamID string) error {
+func (c *Client) DeleteTeam(ctx context.Context, teamID string) error {
 	reqURL := fmt.Sprintf("%s/teams/%s", c.BaseURL, teamID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting team: %w", err)
 	}
@@ -1251,9 +1325,9 @@ func (c *Client) DeleteTeam(teamID string) error {
 }
 
 // GetUsers retrieves all users from DCI
-func (c *Client) GetUsers() (*UsersResponse, error) {
+func (c *Client) GetUsers(ctx context.Context) (*UsersResponse, error) {
 	reqURL := fmt.Sprintf("%s/users", c.BaseURL)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting users: %w", err)
 	}
@@ -1274,9 +1348,9 @@ func (c *Client) GetUsers() (*UsersResponse, error) {
 }
 
 // GetUser retrieves a specific user by ID
-func (c *Client) GetUser(userID string) (*UserResponse, error) {
+func (c *Client) GetUser(ctx context.Context, userID string) (*UserResponse, error) {
 	reqURL := fmt.Sprintf("%s/users/%s", c.BaseURL, userID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting user: %w", err)
 	}
@@ -1297,7 +1371,7 @@ func (c *Client) GetUser(userID string) (*UserResponse, error) {
 }
 
 // CreateUser creates a new user in DCI
-func (c *Client) CreateUser(name, email, fullname, teamID, password string) (*UserResponse, error) {
+func (c *Client) CreateUser(ctx context.Context, name, email, fullname, teamID, password string) (*UserResponse, error) {
 	reqBody := CreateUserRequest{
 		Name:     name,
 		Email:    email,
@@ -1312,7 +1386,7 @@ func (c *Client) CreateUser(name, email, fullname, teamID, password string) (*Us
 	}
 
 	reqURL := fmt.Sprintf("%s/users", c.BaseURL)
-	httpResponse, err := c.doJSON("POST", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPost, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating user: %w", err)
 	}
@@ -1333,14 +1407,14 @@ func (c *Client) CreateUser(name, email, fullname, teamID, password string) (*Us
 }
 
 // UpdateUser updates an existing user in DCI
-func (c *Client) UpdateUser(userID string, updates UpdateUserRequest) (*UserResponse, error) {
+func (c *Client) UpdateUser(ctx context.Context, userID string, updates UpdateUserRequest) (*UserResponse, error) {
 	jsonBody, err := json.Marshal(updates)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request body: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/users/%s", c.BaseURL, userID)
-	httpResponse, err := c.doJSON("PUT", reqURL, jsonBody)
+	httpResponse, err := c.doJSON(ctx, http.MethodPut, reqURL, jsonBody)
 	if err != nil {
 		return nil, fmt.Errorf("error updating user: %w", err)
 	}
@@ -1361,9 +1435,9 @@ func (c *Client) UpdateUser(userID string, updates UpdateUserRequest) (*UserResp
 }
 
 // DeleteUser deletes a user from DCI
-func (c *Client) DeleteUser(userID string) error {
+func (c *Client) DeleteUser(ctx context.Context, userID string) error {
 	reqURL := fmt.Sprintf("%s/users/%s", c.BaseURL, userID)
-	httpResponse, err := c.doRequest("DELETE", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodDelete, reqURL, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting user: %w", err)
 	}
@@ -1379,9 +1453,9 @@ func (c *Client) DeleteUser(userID string) error {
 }
 
 // GetProducts retrieves all products from DCI
-func (c *Client) GetProducts() (*ProductsResponse, error) {
+func (c *Client) GetProducts(ctx context.Context) (*ProductsResponse, error) {
 	reqURL := fmt.Sprintf("%s/products", c.BaseURL)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting products: %w", err)
 	}
@@ -1402,9 +1476,9 @@ func (c *Client) GetProducts() (*ProductsResponse, error) {
 }
 
 // GetProduct retrieves a specific product by ID
-func (c *Client) GetProduct(productID string) (*ProductResponse, error) {
+func (c *Client) GetProduct(ctx context.Context, productID string) (*ProductResponse, error) {
 	reqURL := fmt.Sprintf("%s/products/%s", c.BaseURL, productID)
-	httpResponse, err := c.doRequest("GET", reqURL, nil, nil)
+	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error getting product: %w", err)
 	}

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,7 @@ import (
 )
 
 func newTestClient(serverURL string) *Client {
-	return &Client{BaseURL: serverURL, AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}}
+	return &Client{BaseURL: serverURL, AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}, MaxRetries: 1}
 }
 
 func TestNewClient(t *testing.T) {
@@ -24,6 +25,7 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, "testSecretKey", client.SecretKey)
 	assert.Equal(t, DCIURL, client.BaseURL)
 	assert.NotNil(t, client.httpClient)
+	assert.Equal(t, 3, client.MaxRetries)
 }
 
 func TestGetComponents_EmptyResponse(t *testing.T) {
@@ -42,7 +44,7 @@ func TestGetComponents_EmptyResponse(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	components, err := client.GetComponents()
+	components, err := client.GetComponents(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, components)
 	assert.Len(t, components, 1)
@@ -78,7 +80,7 @@ func TestGetComponents_WithData(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	components, err := client.GetComponents()
+	components, err := client.GetComponents(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, components)
 	assert.Len(t, components, 1)
@@ -114,7 +116,7 @@ func TestGetComponentsByTopicID(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	components, err := client.GetComponentsByTopicID(expectedTopicID)
+	components, err := client.GetComponentsByTopicID(context.Background(), expectedTopicID)
 	assert.NoError(t, err)
 	assert.NotNil(t, components)
 	assert.Len(t, components, 1)
@@ -130,7 +132,7 @@ func TestFetchComponents_Error(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	components, err := client.fetchComponents("", 100, 0)
+	components, err := client.fetchComponents(context.Background(), "", 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, components.Components)
 }
@@ -145,7 +147,7 @@ func TestFetchComponents_InvalidJSON(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	components, err := client.fetchComponents("", 100, 0)
+	components, err := client.fetchComponents(context.Background(), "", 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, components.Components)
 }
@@ -204,7 +206,7 @@ func TestGetIdentity_Success(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, identity)
 	assert.Equal(t, "remoteci-123", identity.Identity.ID)
@@ -237,7 +239,7 @@ func TestGetIdentity_UserType(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, identity)
 	assert.Equal(t, "user", identity.Identity.Type)
@@ -256,9 +258,10 @@ func TestGetIdentity_AuthenticationFailed(t *testing.T) {
 		AccessKey:  "badKey",
 		SecretKey:  "badSecret",
 		httpClient: &http.Client{},
+		MaxRetries: 1,
 	}
 
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, identity)
 	assert.Contains(t, err.Error(), "authentication failed")
@@ -274,7 +277,7 @@ func TestGetIdentity_InvalidJSON(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	identity, err := client.GetIdentity()
+	identity, err := client.GetIdentity(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, identity)
 }
@@ -327,7 +330,7 @@ func TestGetComponentTypes_EmptyResponse(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	componentTypes, err := client.GetComponentTypes()
+	componentTypes, err := client.GetComponentTypes(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, componentTypes)
 	assert.Len(t, componentTypes, 1)
@@ -367,7 +370,7 @@ func TestGetComponentTypes_WithData(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	componentTypes, err := client.GetComponentTypes()
+	componentTypes, err := client.GetComponentTypes(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, componentTypes)
 	assert.Len(t, componentTypes, 1)
@@ -385,7 +388,7 @@ func TestFetchComponentTypes_Error(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	componentTypes, err := client.fetchComponentTypes(100, 0)
+	componentTypes, err := client.fetchComponentTypes(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, componentTypes.ComponentTypes)
 }
@@ -400,7 +403,7 @@ func TestFetchComponentTypes_InvalidJSON(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	componentTypes, err := client.fetchComponentTypes(100, 0)
+	componentTypes, err := client.fetchComponentTypes(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, componentTypes.ComponentTypes)
 }
@@ -469,7 +472,7 @@ func TestCreateJob_Success(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.CreateJob("topic-123", []string{"comp-1", "comp-2"}, "test comment")
+	response, err := client.CreateJob(context.Background(), "topic-123", []string{"comp-1", "comp-2"}, "test comment")
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, "job-456", response.Job.ID)
@@ -487,7 +490,7 @@ func TestCreateJob_Error(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.CreateJob("invalid-topic", nil, "")
+	response, err := client.CreateJob(context.Background(), "invalid-topic", nil, "")
 	assert.Error(t, err)
 	assert.Nil(t, response)
 	assert.Contains(t, err.Error(), "failed to create job")
@@ -519,7 +522,7 @@ func TestUpdateJobState_Success(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.UpdateJobState("job-123", JobStateRunning, "starting test run")
+	response, err := client.UpdateJobState(context.Background(), "job-123", JobStateRunning, "starting test run")
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, "jobstate-789", response.JobState.ID)
@@ -547,7 +550,7 @@ func TestUpdateJobState_ToSuccess(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.UpdateJobState("job-123", JobStateSuccess, "")
+	response, err := client.UpdateJobState(context.Background(), "job-123", JobStateSuccess, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "success", response.JobState.Status)
 }
@@ -573,7 +576,7 @@ func TestUpdateJobState_ToFailure(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.UpdateJobState("job-123", JobStateFailure, "tests failed")
+	response, err := client.UpdateJobState(context.Background(), "job-123", JobStateFailure, "tests failed")
 	assert.NoError(t, err)
 	assert.Equal(t, "failure", response.JobState.Status)
 }
@@ -588,7 +591,7 @@ func TestUpdateJobState_Error(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.UpdateJobState("nonexistent-job", JobStateRunning, "")
+	response, err := client.UpdateJobState(context.Background(), "nonexistent-job", JobStateRunning, "")
 	assert.Error(t, err)
 	assert.Nil(t, response)
 	assert.Contains(t, err.Error(), "failed to update job state")
@@ -620,7 +623,7 @@ func TestUploadFileContent_Success(t *testing.T) {
 	client := newTestClient(server.URL)
 
 	content := []byte("<testsuites><testsuite></testsuite></testsuites>")
-	response, err := client.UploadFileContent("job-123", "test-results.xml", "application/junit", content)
+	response, err := client.UploadFileContent(context.Background(), "job-123", "test-results.xml", "application/junit", content)
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, "file-456", response.File.ID)
@@ -639,7 +642,7 @@ func TestUploadFileContent_Error(t *testing.T) {
 
 	client := newTestClient(server.URL)
 
-	response, err := client.UploadFileContent("invalid-job", "test.xml", "application/junit", []byte("content"))
+	response, err := client.UploadFileContent(context.Background(), "invalid-job", "test.xml", "application/junit", []byte("content"))
 	assert.Error(t, err)
 	assert.Nil(t, response)
 	assert.Contains(t, err.Error(), "failed to upload file")
@@ -714,7 +717,7 @@ func TestGetTopics_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	topics, err := client.GetTopics()
+	topics, err := client.GetTopics(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, topics)
 	assert.Len(t, topics, 1)
@@ -730,7 +733,7 @@ func TestGetTopics_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	topics, err := client.GetTopics()
+	topics, err := client.GetTopics(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, topics)
 }
@@ -748,7 +751,7 @@ func TestGetTopic_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTopic("topic-123")
+	result, err := client.GetTopic(context.Background(), "topic-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "topic-123", result.Topic.ID)
@@ -764,7 +767,7 @@ func TestGetTopic_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTopic("nonexistent")
+	result, err := client.GetTopic(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get topic")
@@ -791,7 +794,7 @@ func TestCreateTopic_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateTopic("OCP-4.15", "prod-1", []string{"ocp", "certsuite"})
+	result, err := client.CreateTopic(context.Background(), "OCP-4.15", "prod-1", []string{"ocp", "certsuite"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-topic", result.Topic.ID)
@@ -806,7 +809,7 @@ func TestCreateTopic_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateTopic("bad", "bad", nil)
+	result, err := client.CreateTopic(context.Background(), "bad", "bad", nil)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create topic")
@@ -825,7 +828,7 @@ func TestUpdateTopic_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateTopic("topic-123", UpdateTopicRequest{Name: "updated-topic"})
+	result, err := client.UpdateTopic(context.Background(), "topic-123", UpdateTopicRequest{Name: "updated-topic"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated-topic", result.Topic.Name)
@@ -840,7 +843,7 @@ func TestUpdateTopic_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateTopic("nonexistent", UpdateTopicRequest{Name: "x"})
+	result, err := client.UpdateTopic(context.Background(), "nonexistent", UpdateTopicRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update topic")
@@ -855,7 +858,7 @@ func TestDeleteTopic_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteTopic("topic-123")
+	err := client.DeleteTopic(context.Background(), "topic-123")
 	assert.NoError(t, err)
 }
 
@@ -868,7 +871,7 @@ func TestDeleteTopic_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteTopic("nonexistent")
+	err := client.DeleteTopic(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete topic")
 }
@@ -891,7 +894,7 @@ func TestGetTopicComponents_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTopicComponents("topic-123")
+	result, err := client.GetTopicComponents(context.Background(), "topic-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result, 1)
@@ -906,7 +909,7 @@ func TestGetTopicComponents_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTopicComponents("topic-123")
+	result, err := client.GetTopicComponents(context.Background(), "topic-123")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -942,7 +945,7 @@ func TestFetchTopics_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopics(100, 0)
+	result, err := client.fetchTopics(context.Background(), 100, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result.Topics, 1)
 	assert.Equal(t, "topic-1", result.Topics[0].ID)
@@ -955,7 +958,7 @@ func TestFetchTopics_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopics(100, 0)
+	result, err := client.fetchTopics(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Topics)
 }
@@ -969,7 +972,7 @@ func TestFetchTopics_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopics(100, 0)
+	result, err := client.fetchTopics(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Topics)
 }
@@ -987,7 +990,7 @@ func TestFetchTopicComponents_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopicComponents("topic-123", 100, 0)
+	result, err := client.fetchTopicComponents(context.Background(), "topic-123", 100, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result.Components, 1)
 	assert.Equal(t, "comp-1", result.Components[0].ID)
@@ -1000,7 +1003,7 @@ func TestFetchTopicComponents_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopicComponents("topic-123", 100, 0)
+	result, err := client.fetchTopicComponents(context.Background(), "topic-123", 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Components)
 }
@@ -1014,7 +1017,7 @@ func TestFetchTopicComponents_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchTopicComponents("topic-123", 100, 0)
+	result, err := client.fetchTopicComponents(context.Background(), "topic-123", 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Components)
 }
@@ -1042,7 +1045,7 @@ func TestGetJobs_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	jobs, err := client.GetJobs(7)
+	jobs, err := client.GetJobs(context.Background(), 7)
 	assert.NoError(t, err)
 	assert.NotNil(t, jobs)
 	assert.Len(t, jobs, 1)
@@ -1057,7 +1060,7 @@ func TestGetJobs_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	jobs, err := client.GetJobs(7)
+	jobs, err := client.GetJobs(context.Background(), 7)
 	assert.Error(t, err)
 	assert.Nil(t, jobs)
 }
@@ -1084,7 +1087,7 @@ func TestGetJobsByDate_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	jobs, err := client.GetJobsByDate(now.Add(-time.Hour), now.Add(time.Hour))
+	jobs, err := client.GetJobsByDate(context.Background(), now.Add(-time.Hour), now.Add(time.Hour))
 	assert.NoError(t, err)
 	assert.NotNil(t, jobs)
 	assert.Len(t, jobs, 1)
@@ -1098,7 +1101,7 @@ func TestGetJobsByDate_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	jobs, err := client.GetJobsByDate(time.Now(), time.Now().Add(time.Hour))
+	jobs, err := client.GetJobsByDate(context.Background(), time.Now(), time.Now().Add(time.Hour))
 	assert.Error(t, err)
 	assert.Nil(t, jobs)
 }
@@ -1116,7 +1119,7 @@ func TestGetJob_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJob("job-123")
+	result, err := client.GetJob(context.Background(), "job-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "job-123", result.Job.ID)
@@ -1132,7 +1135,7 @@ func TestGetJob_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJob("nonexistent")
+	result, err := client.GetJob(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get job")
@@ -1151,7 +1154,7 @@ func TestUpdateJob_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateJob("job-123", UpdateJobRequest{Comment: "updated comment"})
+	result, err := client.UpdateJob(context.Background(), "job-123", UpdateJobRequest{Comment: "updated comment"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated comment", result.Job.Comment)
@@ -1166,7 +1169,7 @@ func TestUpdateJob_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateJob("nonexistent", UpdateJobRequest{Comment: "x"})
+	result, err := client.UpdateJob(context.Background(), "nonexistent", UpdateJobRequest{Comment: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update job")
@@ -1181,7 +1184,7 @@ func TestDeleteJob_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteJob("job-123")
+	err := client.DeleteJob(context.Background(), "job-123")
 	assert.NoError(t, err)
 }
 
@@ -1194,7 +1197,7 @@ func TestDeleteJob_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteJob("nonexistent")
+	err := client.DeleteJob(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete job")
 }
@@ -1219,7 +1222,7 @@ func TestScheduleJob_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.ScheduleJob("topic-123")
+	result, err := client.ScheduleJob(context.Background(), "topic-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "scheduled-job", result.Job.ID)
@@ -1234,7 +1237,7 @@ func TestScheduleJob_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.ScheduleJob("bad-topic")
+	result, err := client.ScheduleJob(context.Background(), "bad-topic")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to schedule job")
@@ -1258,7 +1261,7 @@ func TestGetJobFiles_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJobFiles("job-123")
+	result, err := client.GetJobFiles(context.Background(), "job-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Files, 1)
@@ -1275,7 +1278,7 @@ func TestGetJobFiles_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJobFiles("nonexistent")
+	result, err := client.GetJobFiles(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get job files")
@@ -1299,7 +1302,7 @@ func TestGetJobStates_WithJobID_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJobStates("job-123")
+	result, err := client.GetJobStates(context.Background(), "job-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.JobStates, 1)
@@ -1325,7 +1328,7 @@ func TestGetJobStates_EmptyJobID_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJobStates("")
+	result, err := client.GetJobStates(context.Background(), "")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.JobStates, 2)
@@ -1340,7 +1343,7 @@ func TestGetJobStates_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetJobStates("job-123")
+	result, err := client.GetJobStates(context.Background(), "job-123")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get job states")
@@ -1359,7 +1362,7 @@ func TestFetchJobs_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchJobs(100, 0)
+	result, err := client.fetchJobs(context.Background(), 100, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result.Jobs, 1)
 	assert.Equal(t, "job-1", result.Jobs[0].ID)
@@ -1372,7 +1375,7 @@ func TestFetchJobs_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchJobs(100, 0)
+	result, err := client.fetchJobs(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Jobs)
 }
@@ -1386,7 +1389,7 @@ func TestFetchJobs_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.fetchJobs(100, 0)
+	result, err := client.fetchJobs(context.Background(), 100, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result.Jobs)
 }
@@ -1404,7 +1407,7 @@ func TestGetComponent_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetComponent("comp-123")
+	result, err := client.GetComponent(context.Background(), "comp-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "comp-123", result.Component.ID)
@@ -1420,7 +1423,7 @@ func TestGetComponent_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetComponent("nonexistent")
+	result, err := client.GetComponent(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get component")
@@ -1448,7 +1451,7 @@ func TestCreateComponent_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateComponent("OCP 4.15", "ocp", "topic-123", "4.15.0")
+	result, err := client.CreateComponent(context.Background(), "OCP 4.15", "ocp", "topic-123", "4.15.0")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-comp", result.Component.ID)
@@ -1463,7 +1466,7 @@ func TestCreateComponent_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateComponent("bad", "bad", "bad", "bad")
+	result, err := client.CreateComponent(context.Background(), "bad", "bad", "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create component")
@@ -1482,7 +1485,7 @@ func TestUpdateComponent_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateComponent("comp-123", UpdateComponentRequest{Name: "updated-comp"})
+	result, err := client.UpdateComponent(context.Background(), "comp-123", UpdateComponentRequest{Name: "updated-comp"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated-comp", result.Component.Name)
@@ -1497,7 +1500,7 @@ func TestUpdateComponent_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateComponent("nonexistent", UpdateComponentRequest{Name: "x"})
+	result, err := client.UpdateComponent(context.Background(), "nonexistent", UpdateComponentRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update component")
@@ -1512,7 +1515,7 @@ func TestDeleteComponent_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteComponent("comp-123")
+	err := client.DeleteComponent(context.Background(), "comp-123")
 	assert.NoError(t, err)
 }
 
@@ -1525,7 +1528,7 @@ func TestDeleteComponent_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteComponent("nonexistent")
+	err := client.DeleteComponent(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete component")
 }
@@ -1543,7 +1546,7 @@ func TestGetComponentType_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetComponentType("ct-123")
+	result, err := client.GetComponentType(context.Background(), "ct-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "ct-123", result.ComponentType.ID)
@@ -1559,7 +1562,7 @@ func TestGetComponentType_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetComponentType("nonexistent")
+	result, err := client.GetComponentType(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get component type")
@@ -1579,7 +1582,7 @@ func TestCreateComponentType_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateComponentType("new-type")
+	result, err := client.CreateComponentType(context.Background(), "new-type")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-ct", result.ComponentType.ID)
@@ -1594,7 +1597,7 @@ func TestCreateComponentType_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateComponentType("bad")
+	result, err := client.CreateComponentType(context.Background(), "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create component type")
@@ -1613,7 +1616,7 @@ func TestUpdateComponentType_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateComponentType("ct-123", UpdateComponentTypeRequest{Name: "updated-ct"})
+	result, err := client.UpdateComponentType(context.Background(), "ct-123", UpdateComponentTypeRequest{Name: "updated-ct"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated-ct", result.ComponentType.Name)
@@ -1628,7 +1631,7 @@ func TestUpdateComponentType_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateComponentType("nonexistent", UpdateComponentTypeRequest{Name: "x"})
+	result, err := client.UpdateComponentType(context.Background(), "nonexistent", UpdateComponentTypeRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update component type")
@@ -1643,7 +1646,7 @@ func TestDeleteComponentType_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteComponentType("ct-123")
+	err := client.DeleteComponentType(context.Background(), "ct-123")
 	assert.NoError(t, err)
 }
 
@@ -1656,7 +1659,7 @@ func TestDeleteComponentType_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteComponentType("nonexistent")
+	err := client.DeleteComponentType(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete component type")
 }
@@ -1680,7 +1683,7 @@ func TestGetRemoteCIs_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetRemoteCIs()
+	result, err := client.GetRemoteCIs(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.RemoteCIs, 2)
@@ -1696,7 +1699,7 @@ func TestGetRemoteCIs_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetRemoteCIs()
+	result, err := client.GetRemoteCIs(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get remote CIs")
@@ -1715,7 +1718,7 @@ func TestGetRemoteCI_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetRemoteCI("rci-123")
+	result, err := client.GetRemoteCI(context.Background(), "rci-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "rci-123", result.RemoteCI.ID)
@@ -1731,7 +1734,7 @@ func TestGetRemoteCI_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetRemoteCI("nonexistent")
+	result, err := client.GetRemoteCI(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get remote CI")
@@ -1757,7 +1760,7 @@ func TestCreateRemoteCI_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateRemoteCI("new-remoteci", "team-1")
+	result, err := client.CreateRemoteCI(context.Background(), "new-remoteci", "team-1")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-rci", result.RemoteCI.ID)
@@ -1772,7 +1775,7 @@ func TestCreateRemoteCI_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateRemoteCI("bad", "bad")
+	result, err := client.CreateRemoteCI(context.Background(), "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create remote CI")
@@ -1791,7 +1794,7 @@ func TestUpdateRemoteCI_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateRemoteCI("rci-123", UpdateRemoteCIRequest{Name: "updated-remoteci"})
+	result, err := client.UpdateRemoteCI(context.Background(), "rci-123", UpdateRemoteCIRequest{Name: "updated-remoteci"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated-remoteci", result.RemoteCI.Name)
@@ -1806,7 +1809,7 @@ func TestUpdateRemoteCI_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateRemoteCI("nonexistent", UpdateRemoteCIRequest{Name: "x"})
+	result, err := client.UpdateRemoteCI(context.Background(), "nonexistent", UpdateRemoteCIRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update remote CI")
@@ -1821,7 +1824,7 @@ func TestDeleteRemoteCI_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteRemoteCI("rci-123")
+	err := client.DeleteRemoteCI(context.Background(), "rci-123")
 	assert.NoError(t, err)
 }
 
@@ -1834,7 +1837,7 @@ func TestDeleteRemoteCI_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteRemoteCI("nonexistent")
+	err := client.DeleteRemoteCI(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete remote CI")
 }
@@ -1858,7 +1861,7 @@ func TestGetTeams_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTeams()
+	result, err := client.GetTeams(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Teams, 2)
@@ -1875,7 +1878,7 @@ func TestGetTeams_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTeams()
+	result, err := client.GetTeams(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get teams")
@@ -1894,7 +1897,7 @@ func TestGetTeam_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTeam("team-123")
+	result, err := client.GetTeam(context.Background(), "team-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "team-123", result.Team.ID)
@@ -1910,7 +1913,7 @@ func TestGetTeam_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetTeam("nonexistent")
+	result, err := client.GetTeam(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get team")
@@ -1935,7 +1938,7 @@ func TestCreateTeam_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateTeam("New Team")
+	result, err := client.CreateTeam(context.Background(), "New Team")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-team", result.Team.ID)
@@ -1950,7 +1953,7 @@ func TestCreateTeam_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateTeam("bad")
+	result, err := client.CreateTeam(context.Background(), "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create team")
@@ -1969,7 +1972,7 @@ func TestUpdateTeam_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateTeam("team-123", UpdateTeamRequest{Name: "Updated Team"})
+	result, err := client.UpdateTeam(context.Background(), "team-123", UpdateTeamRequest{Name: "Updated Team"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "Updated Team", result.Team.Name)
@@ -1984,7 +1987,7 @@ func TestUpdateTeam_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateTeam("nonexistent", UpdateTeamRequest{Name: "x"})
+	result, err := client.UpdateTeam(context.Background(), "nonexistent", UpdateTeamRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update team")
@@ -1999,7 +2002,7 @@ func TestDeleteTeam_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteTeam("team-123")
+	err := client.DeleteTeam(context.Background(), "team-123")
 	assert.NoError(t, err)
 }
 
@@ -2012,7 +2015,7 @@ func TestDeleteTeam_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteTeam("nonexistent")
+	err := client.DeleteTeam(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete team")
 }
@@ -2036,7 +2039,7 @@ func TestGetUsers_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetUsers()
+	result, err := client.GetUsers(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Users, 2)
@@ -2053,7 +2056,7 @@ func TestGetUsers_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetUsers()
+	result, err := client.GetUsers(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get users")
@@ -2072,7 +2075,7 @@ func TestGetUser_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetUser("user-123")
+	result, err := client.GetUser(context.Background(), "user-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "user-123", result.User.ID)
@@ -2088,7 +2091,7 @@ func TestGetUser_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetUser("nonexistent")
+	result, err := client.GetUser(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get user")
@@ -2116,7 +2119,7 @@ func TestCreateUser_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateUser("newuser", "new@example.com", "New User", "team-1", "password123")
+	result, err := client.CreateUser(context.Background(), "newuser", "new@example.com", "New User", "team-1", "password123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "new-user", result.User.ID)
@@ -2131,7 +2134,7 @@ func TestCreateUser_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.CreateUser("bad", "bad", "bad", "bad", "bad")
+	result, err := client.CreateUser(context.Background(), "bad", "bad", "bad", "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to create user")
@@ -2150,7 +2153,7 @@ func TestUpdateUser_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateUser("user-123", UpdateUserRequest{Name: "updated-user", Email: "updated@example.com"})
+	result, err := client.UpdateUser(context.Background(), "user-123", UpdateUserRequest{Name: "updated-user", Email: "updated@example.com"})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "updated-user", result.User.Name)
@@ -2165,7 +2168,7 @@ func TestUpdateUser_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.UpdateUser("nonexistent", UpdateUserRequest{Name: "x"})
+	result, err := client.UpdateUser(context.Background(), "nonexistent", UpdateUserRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to update user")
@@ -2180,7 +2183,7 @@ func TestDeleteUser_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteUser("user-123")
+	err := client.DeleteUser(context.Background(), "user-123")
 	assert.NoError(t, err)
 }
 
@@ -2193,7 +2196,7 @@ func TestDeleteUser_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteUser("nonexistent")
+	err := client.DeleteUser(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete user")
 }
@@ -2217,7 +2220,7 @@ func TestGetProducts_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetProducts()
+	result, err := client.GetProducts(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.Products, 2)
@@ -2234,7 +2237,7 @@ func TestGetProducts_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetProducts()
+	result, err := client.GetProducts(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get products")
@@ -2253,7 +2256,7 @@ func TestGetProduct_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetProduct("prod-123")
+	result, err := client.GetProduct(context.Background(), "prod-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "prod-123", result.Product.ID)
@@ -2269,7 +2272,7 @@ func TestGetProduct_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	result, err := client.GetProduct("nonexistent")
+	result, err := client.GetProduct(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get product")
@@ -2290,7 +2293,7 @@ func TestGetFile_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	content, contentType, err := client.GetFile("file-123")
+	content, contentType, err := client.GetFile(context.Background(), "file-123")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContent, content)
 	assert.Equal(t, expectedContentType, contentType)
@@ -2305,7 +2308,7 @@ func TestGetFile_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	content, contentType, err := client.GetFile("nonexistent")
+	content, contentType, err := client.GetFile(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, content)
 	assert.Empty(t, contentType)
@@ -2321,7 +2324,7 @@ func TestDeleteFile_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteFile("file-123")
+	err := client.DeleteFile(context.Background(), "file-123")
 	assert.NoError(t, err)
 }
 
@@ -2334,7 +2337,7 @@ func TestDeleteFile_Error(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteFile("nonexistent")
+	err := client.DeleteFile(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete file")
 }
@@ -2366,7 +2369,7 @@ func TestUploadFile_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := newTestClient(server.URL)
-	result, err := client.UploadFile("job-123", filePath, "application/xml")
+	result, err := client.UploadFile(context.Background(), "job-123", filePath, "application/xml")
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "file-456", result.File.ID)
@@ -2375,8 +2378,8 @@ func TestUploadFile_Success(t *testing.T) {
 }
 
 func TestUploadFile_FileNotFound(t *testing.T) {
-	client := &Client{BaseURL: "http://localhost", AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}}
-	result, err := client.UploadFile("job-123", "/nonexistent/path/file.xml", "application/xml")
+	client := &Client{BaseURL: "http://localhost", AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}, MaxRetries: 1}
+	result, err := client.UploadFile(context.Background(), "job-123", "/nonexistent/path/file.xml", "application/xml")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "error reading file")
@@ -2396,9 +2399,46 @@ func TestUploadFile_Error(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := newTestClient(server.URL)
-	result, err := client.UploadFile("bad-job", filePath, "application/xml")
+	result, err := client.UploadFile(context.Background(), "bad-job", filePath, "application/xml")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to upload file")
 }
 
+func TestDoRequest_RetryOn500(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"ok": true}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}, MaxRetries: 3}
+	resp, err := client.doRequest(context.Background(), "GET", server.URL+"/test", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, attempts)
+	defer func() { _ = resp.Body.Close() }()
+}
+
+func TestDoRequest_NoRetryOn4xx(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := &Client{BaseURL: server.URL, AccessKey: "testKey", SecretKey: "testSecret", httpClient: &http.Client{}, MaxRetries: 3}
+	resp, err := client.doRequest(context.Background(), "GET", server.URL+"/test", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, 1, attempts)
+	defer func() { _ = resp.Body.Close() }()
+}


### PR DESCRIPTION
## Summary

**context.Context (#5):**
- Add `context.Context` as first parameter to all public Client methods (breaking API change, follows Go convention)
- Thread context through `doRequest`, `doJSON`, `paginate`, and all internal fetch helpers
- Use `http.NewRequestWithContext` and context-aware AWS SigV4 signing
- Check `ctx.Err()` in pagination loops for cancellation support
- Update all cmd/ call sites to pass `cmd.Context()` and all examples to pass `context.Background()`

**Retry with backoff (#6):**
- Add `MaxRetries` field to Client struct (default: 3)
- Retry on network errors and 5xx status codes in `doRequest`
- Exponential backoff: 1s, 2s, 4s with +/-25% jitter
- No retry on 4xx (client errors) or 2xx (success)
- Context-aware sleep between retries (`select` on `ctx.Done()`)
- Drain and close response body before retrying 5xx

## Test plan

- [x] `go build ./...` compiles (17 files changed)
- [x] `make test` -- all tests pass (lib tests take ~3s due to retry test backoff)
- [x] `make lint` -- 0 issues
- [x] New test: `TestDoRequest_RetryOn500` verifies retry succeeds after transient 500s
- [x] New test: `TestDoRequest_NoRetryOn4xx` verifies no retry on client errors