### PR TITLE
ci: skip verify-dci job on dependabot PRs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   verify-dci:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The verify-dci job requires DCI secrets which are not available to dependabot, causing all dependabot PRs to fail. This adds an actor check to skip the job for dependabot.