### PR TITLE
chore: update Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sebrandon1/go-dci
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.12


### PR DESCRIPTION
Updates `toolchain` directive in `go.mod` to `go1.26.4`, which fixes two standard library vulnerabilities flagged by govulncheck:

- **GO-2026-5039** — arbitrary inputs unescaped in `net/textproto` errors (fixed in go1.26.4)
- **GO-2026-5037** — inefficient hostname parsing in `crypto/x509` (fixed in go1.26.4)