### PR TITLE
chore: upgrade to Go 1.26.4 and bump codecov-action to v7

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -37,7 +37,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
           fail_ci_if_error: false

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sebrandon1/go-dci
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.26.3 to 1.26.4, fixing 2 stdlib CVEs (net/textproto, crypto/x509)
- Updates codecov/codecov-action from v6 to v7

Mirrors go-quay PRs #109 and #108.