### PR TITLE
docs: slim README and move reference docs to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,54 +5,20 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/sebrandon1/go-dci)](https://golang.org/)
 [![License](https://img.shields.io/github/license/sebrandon1/go-dci)](https://github.com/sebrandon1/go-dci/blob/main/LICENSE)
 
-A Go wrapper around the [Red Hat Distributed CI (DCI) API](https://doc.distributed-ci.io/dci-control-server/docs/API/)
+A Go wrapper around the [Red Hat Distributed CI (DCI) API](https://doc.distributed-ci.io/dci-control-server/docs/API/). Can be used as a standalone CLI tool or imported as a Go library.
 
 ## Quick Start
-
-### Installation
-
-#### Prebuilt binary
-
-Download the latest release for your platform from [GitHub Releases](https://github.com/sebrandon1/go-dci/releases):
-
-```bash
-# Linux (amd64)
-curl -sL https://github.com/sebrandon1/go-dci/releases/latest/download/go-dci_$(curl -sL https://api.github.com/repos/sebrandon1/go-dci/releases/latest | grep tag_name | cut -d '"' -f4)_linux_amd64.tar.gz | tar xz
-sudo mv go-dci /usr/local/bin/
-
-# macOS (Apple Silicon)
-curl -sL https://github.com/sebrandon1/go-dci/releases/latest/download/go-dci_$(curl -sL https://api.github.com/repos/sebrandon1/go-dci/releases/latest | grep tag_name | cut -d '"' -f4)_darwin_arm64.tar.gz | tar xz
-sudo mv go-dci /usr/local/bin/
-```
-
-#### Container image
-
-```bash
-# Using podman
-podman run --rm \
-  -e GO_DCI_ACCESSKEY="$GO_DCI_ACCESSKEY" \
-  -e GO_DCI_SECRETKEY="$GO_DCI_SECRETKEY" \
-  quay.io/bapalm/go-dci identity
-
-# Using docker
-docker run --rm \
-  -e GO_DCI_ACCESSKEY="$GO_DCI_ACCESSKEY" \
-  -e GO_DCI_SECRETKEY="$GO_DCI_SECRETKEY" \
-  quay.io/bapalm/go-dci identity
-```
-
-#### Go install
 
 ```bash
 go install github.com/sebrandon1/go-dci@latest
 ```
 
-#### Build from source
+Configure credentials and verify:
 
 ```bash
-git clone https://github.com/sebrandon1/go-dci.git
-cd go-dci
-make build
+go-dci config set --accesskey <key> --secretkey <secret>
+go-dci identity
+go-dci topics
 ```
 
 ### Library Usage
@@ -92,412 +58,32 @@ func main() {
 }
 ```
 
-### CLI Usage
+## Guides
 
-```bash
-# Configure credentials
-go-dci config set --accesskey <your-access-key> --secretkey <your-secret-key>
-
-# Verify authentication
-go-dci identity
-
-# List topics
-go-dci topics
-
-# Get recent jobs
-go-dci jobs -d 30
-
-# Or run via container
-podman run --rm \
-  -e GO_DCI_ACCESSKEY="$GO_DCI_ACCESSKEY" \
-  -e GO_DCI_SECRETKEY="$GO_DCI_SECRETKEY" \
-  quay.io/bapalm/go-dci topics
-```
-
-## Documentation
-
-- **[Library Guide](./docs/library-guide.md)** - Complete API reference for using go-dci as a library
-- **[Examples](./examples/)** - Runnable example programs
-  - [Basic Usage](./examples/basic-usage/) - Authentication, topics, components, jobs
-  - [Certification Workflow](./examples/certification-workflow/) - Complete certification job lifecycle
-  - [Component Query](./examples/component-query/) - Component filtering and version analysis
-
-### Tutorials
-
-Step-by-step guides for common workflows:
-
-1. [Getting Started](./docs/tutorials/01-getting-started.md) - Installation, authentication, first API calls
-2. [Certification Workflow](./docs/tutorials/02-certification-workflow.md) - Complete job lifecycle
-3. [Component Analysis](./docs/tutorials/03-component-analysis.md) - Query and analyze components
+| Guide | Description |
+|-------|-------------|
+| [Installation](docs/installation.md) | Prebuilt binaries, container image, go install, build from source |
+| [Authentication](docs/authentication.md) | Config file and environment variable setup |
+| [CLI Reference](docs/cli-reference.md) | All commands with flags and example output |
+| [Library Guide](docs/library-guide.md) | Complete API reference for using go-dci as a library |
+| [Tutorials](docs/tutorials/) | Step-by-step guides for common workflows |
+| [Examples](examples/) | Runnable example programs |
 
 ## Supported DCI API Endpoints
 
-| Endpoint | CLI Command | Lib | Covered |
-|----------|-------------|-----|---------|
-| `/api/v1/identity` | `identity` | Yes | GET |
-| `/api/v1/topics` | `topics`, `get-topic`, `create-topic`, `update-topic`, `delete-topic`, `topic-components` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/jobs` | `jobs`, `ocpcount`, `create-job`, `get-job`, `update-job`, `delete-job`, `schedule-job`, `job-files` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/components` | `components`, `get-component`, `create-component`, `update-component`, `delete-component` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/componenttypes` | `componenttypes`, `get-componenttype`, `create-componenttype`, `update-componenttype`, `delete-componenttype` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/jobstates` | `update-job-state`, `get-jobstates` | Yes | GET, POST |
-| `/api/v1/files` | `upload-file` | Yes | GET, POST, DELETE |
-| `/api/v1/remotecis` | `get-remotecis`, `get-remoteci`, `create-remoteci`, `update-remoteci`, `delete-remoteci` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/teams` | `get-teams`, `get-team`, `create-team`, `update-team`, `delete-team` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/users` | `get-users`, `get-user`, `create-user`, `update-user`, `delete-user` | Yes | GET, GET/:id, POST, PUT, DELETE |
-| `/api/v1/products` | `get-products`, `get-product` | Yes | GET, GET/:id |
-
-## Authentication
-
-All API commands require DCI RemoteCI credentials. You can obtain credentials from the [DCI dashboard](https://www.distributed-ci.io/).
-
-### Configuration
-
-Set up your DCI RemoteCI credentials using one of the following methods:
-
-#### Option 1: Config File
-
-```bash
-go-dci config set --accesskey <your-access-key> --secretkey <your-secret-key>
-```
-
-This creates a `.go-dci-config.yaml` file in the current directory.
-
-```
-Usage:
-  dci config set [flags]
-
-Flags:
-  -a, --accesskey string   The access key to set in the configuration.
-  -h, --help               help for set
-  -s, --secretkey string   The secret key to set in the configuration.
-```
-
-#### Option 2: Environment Variables
-
-You can also set credentials via environment variables (useful for CI/CD):
-
-```bash
-export GO_DCI_ACCESSKEY=<your-access-key>
-export GO_DCI_SECRETKEY=<your-secret-key>
-```
-
-| Variable | Description |
-|----------|-------------|
-| `GO_DCI_ACCESSKEY` | Your DCI client ID / access key |
-| `GO_DCI_SECRETKEY` | Your DCI API secret key |
-
-Environment variables take precedence over values in the config file.
-
-## Usage Examples
-
-### `topics` - List Topics
-
-Get all available topics from DCI.
-
-```bash
-# Get all topics
-go-dci topics
-
-# Output as JSON
-go-dci topics --output json
-```
-
-```
-Usage:
-  dci topics [flags]
-
-Flags:
-  -h, --help            help for topics
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-Example output:
-
-```
-Getting all topics from DCI
-ID: topic-123 | Name: OCP-4.14 | Product: OpenShift Container Platform | State: active
-ID: topic-456 | Name: OCP-4.15 | Product: OpenShift Container Platform | State: active
-Total Topics: 2
-```
-
-### `identity` - Verify Authentication
-
-Verify your DCI credentials are configured correctly and display identity information.
-
-```bash
-# Check authentication
-go-dci identity
-
-# Output as JSON
-go-dci identity --output json
-```
-
-```
-Usage:
-  dci identity [flags]
-
-Flags:
-  -h, --help            help for identity
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-Example output:
-
-```
-Authentication successful!
----
-ID:       abc123-def456-ghi789
-Name:     my-remoteci
-Type:     remoteci
-Team:     My Team
-Team ID:  team-123
-State:    active
-```
-
-### `jobs` - Query Jobs
-
-Get all jobs with a specific age in days. Filters for jobs running the [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite).
-
-```bash
-# Get jobs from the last 30 days
-go-dci jobs -d 30
-
-# Output as JSON
-go-dci jobs -d 30 --output json
-```
-
-```
-Usage:
-  dci jobs [flags]
-
-Flags:
-  -d, --age string      Age in days
-  -h, --help            help for jobs
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-Example output:
-
-```
-Getting all jobs from DCI that are 30 days old
-Job ID: 78ed13e1-841f-4c04-a1c6-8df9028c67cd  -  Certsuite Version: tnf-v5.1.3 (Days Since: 11.249845)
-Job ID: eb491abd-ec8b-42cc-aa8b-98adf741b236  -  Certsuite Version: tnf-v5.1.3 (Days Since: 11.305408)
-```
-
-### `ocpcount` - OCP Version Statistics
-
-Get the count of certsuite jobs for each OCP version.
-
-```bash
-# Get OCP version counts for the last 30 days
-go-dci ocpcount -d 30
-
-# Output as JSON
-go-dci ocpcount -d 30 --output json
-```
-
-```
-Usage:
-  dci ocpcount [flags]
-
-Flags:
-  -d, --age string      Age in days
-  -h, --help            help for ocpcount
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-### `componenttypes` - List Component Types
-
-Get all available component types from DCI.
-
-```bash
-# Get all component types
-go-dci componenttypes
-
-# Output as JSON
-go-dci componenttypes --output json
-```
-
-```
-Usage:
-  dci componenttypes [flags]
-
-Flags:
-  -h, --help            help for componenttypes
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-Example output:
-
-```
-Getting all component types from DCI
-ID: ct-123 | Name: ocp | State: active
-ID: ct-456 | Name: certsuite | State: active
-ID: ct-789 | Name: rhel | State: active
-Total Component Types: 3
-```
-
-### `components` - Query Components
-
-Get all components, optionally filtered by topic ID.
-
-```bash
-# Get all components
-go-dci components
-
-# Get components for a specific topic
-go-dci components --topic <topic-id>
-
-# Output as JSON
-go-dci components --output json
-```
-
-```
-Usage:
-  dci components [flags]
-
-Flags:
-  -h, --help            help for components
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-  -t, --topic string    Filter components by topic ID
-```
-
-Example output:
-
-```
-Getting all components from DCI
-ID: abc123 | Name: OpenShift 4.14.1 | Type: ocp | Version: 4.14.1 | TopicID: topic-456
-ID: def456 | Name: certsuite v5.1.3 | Type: certsuite | Version: v5.1.3 | TopicID: topic-456
-Total Components: 2
-```
-
-### `create-job` - Create a New Job
-
-Create a new job in DCI for a given topic.
-
-```bash
-# Create a job for a topic
-go-dci create-job --topic-id <topic-id>
-
-# Create a job with specific components
-go-dci create-job --topic-id <topic-id> --components <comp-id-1>,<comp-id-2>
-
-# Create a job with a comment
-go-dci create-job --topic-id <topic-id> --comment "Test run for certification"
-
-# Output as JSON
-go-dci create-job --topic-id <topic-id> --output json
-```
-
-```
-Usage:
-  dci create-job [flags]
-
-Flags:
-      --comment string      Optional comment for the job
-      --components string   Comma-separated list of component IDs
-  -h, --help                help for create-job
-  -o, --output string       Output format (json) - default is stdout (default "stdout")
-      --topic-id string     Topic ID for the job (required)
-```
-
-Example output:
-
-```
-Creating job for topic ID: topic-123
-Job created successfully!
----
-Job ID:    job-456
-Topic ID:  topic-123
-Status:    new
-State:     active
-Created:   2024-01-01T00:00:00.000000
-```
-
-### `update-job-state` - Update Job State
-
-Update the state of a job (pre-run, running, success, failure, etc.).
-
-```bash
-# Update job to running state
-go-dci update-job-state --job-id <job-id> --status running
-
-# Update job to success with comment
-go-dci update-job-state --job-id <job-id> --status success --comment "All tests passed"
-
-# Update job to failure
-go-dci update-job-state --job-id <job-id> --status failure --comment "Tests failed"
-
-# Output as JSON
-go-dci update-job-state --job-id <job-id> --status success --output json
-```
-
-```
-Usage:
-  dci update-job-state [flags]
-
-Flags:
-      --comment string   Optional comment for the state change
-  -h, --help             help for update-job-state
-      --job-id string    Job ID to update (required)
-  -o, --output string    Output format (json) - default is stdout (default "stdout")
-      --status string    New status (pre-run, running, success, failure, etc.) (required)
-```
-
-Valid status values: `new`, `pre-run`, `running`, `post-run`, `success`, `failure`, `killed`, `error`
-
-Example output:
-
-```
-Updating job job-123 to status: running
-Job state updated successfully!
----
-JobState ID: jobstate-789
-Job ID:      job-123
-Status:      running
-Created:     2024-01-01T00:00:00.000000
-```
-
-### `upload-file` - Upload File to Job
-
-Upload a file (e.g., test results) to a job in DCI.
-
-```bash
-# Upload a JUnit test results file
-go-dci upload-file --job-id <job-id> --file /path/to/results.xml
-
-# Upload with custom MIME type
-go-dci upload-file --job-id <job-id> --file /path/to/results.json --mime application/json
-
-# Output as JSON
-go-dci upload-file --job-id <job-id> --file /path/to/results.xml --output json
-```
-
-```
-Usage:
-  dci upload-file [flags]
-
-Flags:
-      --file string     Path to the file to upload (required)
-  -h, --help            help for upload-file
-      --job-id string   Job ID to attach the file to (required)
-      --mime string     MIME type of the file (default "application/junit")
-  -o, --output string   Output format (json) - default is stdout (default "stdout")
-```
-
-Example output:
-
-```
-Uploading file results.xml to job job-123
-File uploaded successfully!
----
-File ID:   file-456
-Job ID:    job-123
-Name:      results.xml
-MIME Type: application/junit
-Size:      1024 bytes
-Created:   2024-01-01T00:00:00.000000
-```
+| Endpoint | CLI Commands |
+|----------|--------------|
+| `/api/v1/identity` | `identity` |
+| `/api/v1/topics` | `topics`, `get-topic`, `create-topic`, `update-topic`, `delete-topic`, `topic-components` |
+| `/api/v1/jobs` | `jobs`, `ocpcount`, `create-job`, `get-job`, `update-job`, `delete-job`, `schedule-job`, `job-files` |
+| `/api/v1/components` | `components`, `get-component`, `create-component`, `update-component`, `delete-component` |
+| `/api/v1/componenttypes` | `componenttypes`, `get-componenttype`, `create-componenttype`, `update-componenttype`, `delete-componenttype` |
+| `/api/v1/jobstates` | `update-job-state`, `get-jobstates` |
+| `/api/v1/files` | `upload-file` |
+| `/api/v1/remotecis` | `get-remotecis`, `get-remoteci`, `create-remoteci`, `update-remoteci`, `delete-remoteci` |
+| `/api/v1/teams` | `get-teams`, `get-team`, `create-team`, `update-team`, `delete-team` |
+| `/api/v1/users` | `get-users`, `get-user`, `create-user`, `update-user`, `delete-user` |
+| `/api/v1/products` | `get-products`, `get-product` |
 
 ## Development
 
@@ -508,3 +94,7 @@ make lint     # Run linters
 make vet      # Run go vet
 make clean    # Remove binary
 ```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues and pull requests.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,41 @@
+# Authentication
+
+All API commands require DCI RemoteCI credentials. You can obtain credentials from the [DCI dashboard](https://www.distributed-ci.io/).
+
+## Option 1: Config File
+
+```bash
+go-dci config set --accesskey <your-access-key> --secretkey <your-secret-key>
+```
+
+This creates a `.go-dci-config.yaml` file in the current directory.
+
+```
+Usage:
+  dci config set [flags]
+
+Flags:
+  -a, --accesskey string   The access key to set in the configuration.
+  -h, --help               help for set
+  -s, --secretkey string   The secret key to set in the configuration.
+```
+
+## Option 2: Environment Variables
+
+You can also set credentials via environment variables (useful for CI/CD):
+
+```bash
+export GO_DCI_ACCESSKEY=<your-access-key>
+export GO_DCI_SECRETKEY=<your-secret-key>
+```
+
+| Variable | Description |
+|----------|-------------|
+| `GO_DCI_ACCESSKEY` | Your DCI client ID / access key |
+| `GO_DCI_SECRETKEY` | Your DCI API secret key |
+
+Environment variables take precedence over values in the config file.
+
+---
+
+Next: [CLI Reference](cli-reference.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,310 @@
+# CLI Reference
+
+## `topics` — List Topics
+
+Get all available topics from DCI.
+
+```bash
+# Get all topics
+go-dci topics
+
+# Output as JSON
+go-dci topics --output json
+```
+
+```
+Usage:
+  dci topics [flags]
+
+Flags:
+  -h, --help            help for topics
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+Example output:
+
+```
+Getting all topics from DCI
+ID: topic-123 | Name: OCP-4.14 | Product: OpenShift Container Platform | State: active
+ID: topic-456 | Name: OCP-4.15 | Product: OpenShift Container Platform | State: active
+Total Topics: 2
+```
+
+## `identity` — Verify Authentication
+
+Verify your DCI credentials are configured correctly and display identity information.
+
+```bash
+# Check authentication
+go-dci identity
+
+# Output as JSON
+go-dci identity --output json
+```
+
+```
+Usage:
+  dci identity [flags]
+
+Flags:
+  -h, --help            help for identity
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+Example output:
+
+```
+Authentication successful!
+---
+ID:       abc123-def456-ghi789
+Name:     my-remoteci
+Type:     remoteci
+Team:     My Team
+Team ID:  team-123
+State:    active
+```
+
+## `jobs` — Query Jobs
+
+Get all jobs with a specific age in days. Filters for jobs running the [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite).
+
+```bash
+# Get jobs from the last 30 days
+go-dci jobs -d 30
+
+# Output as JSON
+go-dci jobs -d 30 --output json
+```
+
+```
+Usage:
+  dci jobs [flags]
+
+Flags:
+  -d, --age string      Age in days
+  -h, --help            help for jobs
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+Example output:
+
+```
+Getting all jobs from DCI that are 30 days old
+Job ID: 78ed13e1-841f-4c04-a1c6-8df9028c67cd  -  Certsuite Version: tnf-v5.1.3 (Days Since: 11.249845)
+Job ID: eb491abd-ec8b-42cc-aa8b-98adf741b236  -  Certsuite Version: tnf-v5.1.3 (Days Since: 11.305408)
+```
+
+## `ocpcount` — OCP Version Statistics
+
+Get the count of certsuite jobs for each OCP version.
+
+```bash
+# Get OCP version counts for the last 30 days
+go-dci ocpcount -d 30
+
+# Output as JSON
+go-dci ocpcount -d 30 --output json
+```
+
+```
+Usage:
+  dci ocpcount [flags]
+
+Flags:
+  -d, --age string      Age in days
+  -h, --help            help for ocpcount
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+## `componenttypes` — List Component Types
+
+Get all available component types from DCI.
+
+```bash
+# Get all component types
+go-dci componenttypes
+
+# Output as JSON
+go-dci componenttypes --output json
+```
+
+```
+Usage:
+  dci componenttypes [flags]
+
+Flags:
+  -h, --help            help for componenttypes
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+Example output:
+
+```
+Getting all component types from DCI
+ID: ct-123 | Name: ocp | State: active
+ID: ct-456 | Name: certsuite | State: active
+ID: ct-789 | Name: rhel | State: active
+Total Component Types: 3
+```
+
+## `components` — Query Components
+
+Get all components, optionally filtered by topic ID.
+
+```bash
+# Get all components
+go-dci components
+
+# Get components for a specific topic
+go-dci components --topic <topic-id>
+
+# Output as JSON
+go-dci components --output json
+```
+
+```
+Usage:
+  dci components [flags]
+
+Flags:
+  -h, --help            help for components
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+  -t, --topic string    Filter components by topic ID
+```
+
+Example output:
+
+```
+Getting all components from DCI
+ID: abc123 | Name: OpenShift 4.14.1 | Type: ocp | Version: 4.14.1 | TopicID: topic-456
+ID: def456 | Name: certsuite v5.1.3 | Type: certsuite | Version: v5.1.3 | TopicID: topic-456
+Total Components: 2
+```
+
+## `create-job` — Create a New Job
+
+Create a new job in DCI for a given topic.
+
+```bash
+# Create a job for a topic
+go-dci create-job --topic-id <topic-id>
+
+# Create a job with specific components
+go-dci create-job --topic-id <topic-id> --components <comp-id-1>,<comp-id-2>
+
+# Create a job with a comment
+go-dci create-job --topic-id <topic-id> --comment "Test run for certification"
+
+# Output as JSON
+go-dci create-job --topic-id <topic-id> --output json
+```
+
+```
+Usage:
+  dci create-job [flags]
+
+Flags:
+      --comment string      Optional comment for the job
+      --components string   Comma-separated list of component IDs
+  -h, --help                help for create-job
+  -o, --output string       Output format (json) - default is stdout (default "stdout")
+      --topic-id string     Topic ID for the job (required)
+```
+
+Example output:
+
+```
+Creating job for topic ID: topic-123
+Job created successfully!
+---
+Job ID:    job-456
+Topic ID:  topic-123
+Status:    new
+State:     active
+Created:   2024-01-01T00:00:00.000000
+```
+
+## `update-job-state` — Update Job State
+
+Update the state of a job (pre-run, running, success, failure, etc.).
+
+```bash
+# Update job to running state
+go-dci update-job-state --job-id <job-id> --status running
+
+# Update job to success with comment
+go-dci update-job-state --job-id <job-id> --status success --comment "All tests passed"
+
+# Update job to failure
+go-dci update-job-state --job-id <job-id> --status failure --comment "Tests failed"
+
+# Output as JSON
+go-dci update-job-state --job-id <job-id> --status success --output json
+```
+
+```
+Usage:
+  dci update-job-state [flags]
+
+Flags:
+      --comment string   Optional comment for the state change
+  -h, --help             help for update-job-state
+      --job-id string    Job ID to update (required)
+  -o, --output string    Output format (json) - default is stdout (default "stdout")
+      --status string    New status (pre-run, running, success, failure, etc.) (required)
+```
+
+Valid status values: `new`, `pre-run`, `running`, `post-run`, `success`, `failure`, `killed`, `error`
+
+Example output:
+
+```
+Updating job job-123 to status: running
+Job state updated successfully!
+---
+JobState ID: jobstate-789
+Job ID:      job-123
+Status:      running
+Created:     2024-01-01T00:00:00.000000
+```
+
+## `upload-file` — Upload File to Job
+
+Upload a file (e.g., test results) to a job in DCI.
+
+```bash
+# Upload a JUnit test results file
+go-dci upload-file --job-id <job-id> --file /path/to/results.xml
+
+# Upload with custom MIME type
+go-dci upload-file --job-id <job-id> --file /path/to/results.json --mime application/json
+
+# Output as JSON
+go-dci upload-file --job-id <job-id> --file /path/to/results.xml --output json
+```
+
+```
+Usage:
+  dci upload-file [flags]
+
+Flags:
+      --file string     Path to the file to upload (required)
+  -h, --help            help for upload-file
+      --job-id string   Job ID to attach the file to (required)
+      --mime string     MIME type of the file (default "application/junit")
+  -o, --output string   Output format (json) - default is stdout (default "stdout")
+```
+
+Example output:
+
+```
+Uploading file results.xml to job job-123
+File uploaded successfully!
+---
+File ID:   file-456
+Job ID:    job-123
+Name:      results.xml
+MIME Type: application/junit
+Size:      1024 bytes
+Created:   2024-01-01T00:00:00.000000
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,49 @@
+# Installation
+
+## Prebuilt Binary
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/sebrandon1/go-dci/releases):
+
+```bash
+# Linux (amd64)
+curl -sL https://github.com/sebrandon1/go-dci/releases/latest/download/go-dci_$(curl -sL https://api.github.com/repos/sebrandon1/go-dci/releases/latest | grep tag_name | cut -d '"' -f4)_linux_amd64.tar.gz | tar xz
+sudo mv go-dci /usr/local/bin/
+
+# macOS (Apple Silicon)
+curl -sL https://github.com/sebrandon1/go-dci/releases/latest/download/go-dci_$(curl -sL https://api.github.com/repos/sebrandon1/go-dci/releases/latest | grep tag_name | cut -d '"' -f4)_darwin_arm64.tar.gz | tar xz
+sudo mv go-dci /usr/local/bin/
+```
+
+## Container Image
+
+```bash
+# Using podman
+podman run --rm \
+  -e GO_DCI_ACCESSKEY="$GO_DCI_ACCESSKEY" \
+  -e GO_DCI_SECRETKEY="$GO_DCI_SECRETKEY" \
+  quay.io/bapalm/go-dci identity
+
+# Using docker
+docker run --rm \
+  -e GO_DCI_ACCESSKEY="$GO_DCI_ACCESSKEY" \
+  -e GO_DCI_SECRETKEY="$GO_DCI_SECRETKEY" \
+  quay.io/bapalm/go-dci identity
+```
+
+## Go Install
+
+```bash
+go install github.com/sebrandon1/go-dci@latest
+```
+
+## Build from Source
+
+```bash
+git clone https://github.com/sebrandon1/go-dci.git
+cd go-dci
+make build
+```
+
+---
+
+Next: [Authentication](authentication.md)


### PR DESCRIPTION
## Summary
- Reduces README from ~470 lines to ~100 lines, keeping quick start and library usage
- Moves CLI reference examples to `docs/cli-reference.md`
- Moves installation methods (binary, container, go install, source) to `docs/installation.md`
- Moves authentication/config details to `docs/authentication.md`
- Zero content loss — all examples preserved in docs/

Mirrors go-quay PR #111.