### PR TITLE
docs: fix broken tutorials by adding context.Context to API examples

### DIFF
--- a/docs/tutorials/01-getting-started.md
+++ b/docs/tutorials/01-getting-started.md
@@ -94,6 +94,7 @@ Test your credentials by getting your identity:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -108,7 +109,8 @@ func main() {
     client := lib.NewClient(accessKey, secretKey)
 
     // Verify authentication
-    identity, err := client.GetIdentity()
+    ctx := context.Background()
+    identity, err := client.GetIdentity(ctx)
     if err != nil {
         log.Fatalf("Authentication failed: %v", err)
     }
@@ -125,7 +127,8 @@ Topics represent test suites or certification programs:
 
 ```go
 // Get all topics
-topicsResp, err := client.GetTopics()
+ctx := context.Background()
+topicsResp, err := client.GetTopics(ctx)
 if err != nil {
     log.Fatalf("Failed to get topics: %v", err)
 }
@@ -145,7 +148,8 @@ Components represent test artifacts (e.g., OCP versions, test tools):
 
 ```go
 // Get all components
-componentsResp, err := client.GetComponents()
+ctx := context.Background()
+componentsResp, err := client.GetComponents(ctx)
 if err != nil {
     log.Fatalf("Failed to get components: %v", err)
 }
@@ -159,7 +163,7 @@ for _, resp := range componentsResp {
 }
 
 // Get components for a specific topic
-topicComponents, err := client.GetTopicComponents("topic-uuid-here")
+topicComponents, err := client.GetTopicComponents(ctx, "topic-uuid-here")
 ```
 
 ## Understanding DCI Concepts
@@ -187,7 +191,8 @@ Attach test results and logs to jobs.
 ## Error Handling
 
 ```go
-identity, err := client.GetIdentity()
+ctx := context.Background()
+identity, err := client.GetIdentity(ctx)
 if err != nil {
     // Check error type
     if strings.Contains(err.Error(), "401") {

--- a/docs/tutorials/02-certification-workflow.md
+++ b/docs/tutorials/02-certification-workflow.md
@@ -35,6 +35,7 @@ First, identify the topic for your certification:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -49,7 +50,8 @@ func main() {
     )
 
     // List available topics
-    topicsResp, err := client.GetTopics()
+    ctx := context.Background()
+    topicsResp, err := client.GetTopics(ctx)
     if err != nil {
         log.Fatalf("Failed to get topics: %v", err)
     }
@@ -72,7 +74,8 @@ Find available components for testing:
 topicID := "your-topic-uuid"
 
 // Get components for the topic
-componentsResp, err := client.GetTopicComponents(topicID)
+ctx := context.Background()
+componentsResp, err := client.GetTopicComponents(ctx, topicID)
 if err != nil {
     log.Fatalf("Failed to get components: %v", err)
 }
@@ -92,7 +95,9 @@ Create a new certification job:
 
 ```go
 // Create job with specific components
+ctx := context.Background()
 job, err := client.CreateJob(
+    ctx,
     topicID,
     componentIDs,              // Components to test against
     "Certification run via API", // Comment
@@ -110,7 +115,8 @@ jobID := job.Job.ID
 Alternatively, schedule a job (auto-selects latest components):
 
 ```go
-job, err := client.ScheduleJob(topicID)
+ctx := context.Background()
+job, err := client.ScheduleJob(ctx, topicID)
 if err != nil {
     log.Fatalf("Failed to schedule job: %v", err)
 }
@@ -122,7 +128,8 @@ Progress the job through its lifecycle:
 
 ```go
 // Move to pre-run
-_, err = client.UpdateJobState(jobID, lib.JobStatePreRun, "Starting pre-run setup")
+ctx := context.Background()
+_, err = client.UpdateJobState(ctx, jobID, lib.JobStatePreRun, "Starting pre-run setup")
 if err != nil {
     log.Fatalf("Failed to update state: %v", err)
 }
@@ -131,7 +138,7 @@ fmt.Println("State: pre-run")
 // Perform pre-run setup here...
 
 // Move to running
-_, err = client.UpdateJobState(jobID, lib.JobStateRunning, "Executing tests")
+_, err = client.UpdateJobState(ctx, jobID, lib.JobStateRunning, "Executing tests")
 if err != nil {
     log.Fatalf("Failed to update state: %v", err)
 }
@@ -159,7 +166,9 @@ Attach test results to the job:
 
 ```go
 // Upload from a file
+ctx := context.Background()
 uploadResp, err := client.UploadFile(
+    ctx,
     jobID,
     "/path/to/results.xml",
     "application/junit",
@@ -175,8 +184,10 @@ if err != nil {
 
 ```go
 // Upload content directly
+ctx := context.Background()
 content := []byte("<testsuite>...</testsuite>")
 uploadResp, err := client.UploadFileContent(
+    ctx,
     jobID,
     "results.xml",
     "application/junit",
@@ -200,13 +211,14 @@ Set the final job state:
 
 ```go
 // Tests passed
-_, err = client.UpdateJobState(jobID, lib.JobStateSuccess, "All tests passed")
+ctx := context.Background()
+_, err = client.UpdateJobState(ctx, jobID, lib.JobStateSuccess, "All tests passed")
 if err != nil {
     log.Fatalf("Failed to update state: %v", err)
 }
 
 // Or if tests failed
-_, err = client.UpdateJobState(jobID, lib.JobStateFailure, "Some tests failed")
+_, err = client.UpdateJobState(ctx, jobID, lib.JobStateFailure, "Some tests failed")
 ```
 
 ## Step 7: Query Job Status
@@ -215,7 +227,8 @@ Check job state at any time:
 
 ```go
 // Get job details
-job, err := client.GetJob(jobID)
+ctx := context.Background()
+job, err := client.GetJob(ctx, jobID)
 if err != nil {
     log.Fatalf("Failed to get job: %v", err)
 }
@@ -229,7 +242,8 @@ fmt.Printf("Updated: %s\n", job.Job.UpdatedAt)
 ### Get Job State History
 
 ```go
-states, err := client.GetJobStates(jobID)
+ctx := context.Background()
+states, err := client.GetJobStates(ctx, jobID)
 if err != nil {
     log.Fatalf("Failed to get states: %v", err)
 }
@@ -246,7 +260,8 @@ for _, state := range states.JobStates {
 ### Get Job Files
 
 ```go
-files, err := client.GetJobFiles(jobID)
+ctx := context.Background()
+files, err := client.GetJobFiles(ctx, jobID)
 if err != nil {
     log.Fatalf("Failed to get files: %v", err)
 }
@@ -263,6 +278,7 @@ for _, file := range files.Files {
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -277,10 +293,11 @@ func main() {
         os.Getenv("GO_DCI_SECRETKEY"),
     )
 
+    ctx := context.Background()
     topicID := "your-topic-id"
 
     // 1. Get components
-    componentsResp, _ := client.GetTopicComponents(topicID)
+    componentsResp, _ := client.GetTopicComponents(ctx, topicID)
     var componentIDs []string
     for _, resp := range componentsResp {
         for _, comp := range resp.Components {
@@ -289,7 +306,7 @@ func main() {
     }
 
     // 2. Create job
-    job, err := client.CreateJob(topicID, componentIDs, "Automated certification")
+    job, err := client.CreateJob(ctx, topicID, componentIDs, "Automated certification")
     if err != nil {
         log.Fatal(err)
     }
@@ -297,23 +314,23 @@ func main() {
     fmt.Printf("Created job: %s\n", jobID)
 
     // 3. Pre-run
-    client.UpdateJobState(jobID, lib.JobStatePreRun, "Setting up environment")
+    client.UpdateJobState(ctx, jobID, lib.JobStatePreRun, "Setting up environment")
     time.Sleep(time.Second)
 
     // 4. Running
-    client.UpdateJobState(jobID, lib.JobStateRunning, "Executing tests")
+    client.UpdateJobState(ctx, jobID, lib.JobStateRunning, "Executing tests")
 
     // 5. Execute your tests here...
     testsPassed := runTests()
 
     // 6. Upload results
-    client.UploadFile(jobID, "results.xml", "application/junit")
+    client.UploadFile(ctx, jobID, "results.xml", "application/junit")
 
     // 7. Set final state
     if testsPassed {
-        client.UpdateJobState(jobID, lib.JobStateSuccess, "All tests passed")
+        client.UpdateJobState(ctx, jobID, lib.JobStateSuccess, "All tests passed")
     } else {
-        client.UpdateJobState(jobID, lib.JobStateFailure, "Some tests failed")
+        client.UpdateJobState(ctx, jobID, lib.JobStateFailure, "Some tests failed")
     }
 
     fmt.Println("Workflow complete!")
@@ -330,9 +347,10 @@ func runTests() bool {
 ```go
 // Retry on transient failures
 func updateStateWithRetry(client *lib.Client, jobID string, state lib.JobState, comment string) error {
+    ctx := context.Background()
     maxRetries := 3
     for i := 0; i < maxRetries; i++ {
-        _, err := client.UpdateJobState(jobID, state, comment)
+        _, err := client.UpdateJobState(ctx, jobID, state, comment)
         if err == nil {
             return nil
         }

--- a/docs/tutorials/03-component-analysis.md
+++ b/docs/tutorials/03-component-analysis.md
@@ -29,6 +29,7 @@ Each component has:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -43,7 +44,8 @@ func main() {
     )
 
     // Get all components
-    componentsResp, err := client.GetComponents()
+    ctx := context.Background()
+    componentsResp, err := client.GetComponents(ctx)
     if err != nil {
         log.Fatalf("Failed to get components: %v", err)
     }
@@ -67,7 +69,8 @@ Get components for a specific certification topic:
 ```go
 topicID := "your-topic-uuid"
 
-componentsResp, err := client.GetTopicComponents(topicID)
+ctx := context.Background()
+componentsResp, err := client.GetTopicComponents(ctx, topicID)
 if err != nil {
     log.Fatalf("Failed to get components: %v", err)
 }
@@ -84,7 +87,8 @@ for _, resp := range componentsResp {
 ```go
 topicID := "your-topic-uuid"
 
-componentsResp, err := client.GetComponentsByTopicID(topicID)
+ctx := context.Background()
+componentsResp, err := client.GetComponentsByTopicID(ctx, topicID)
 if err != nil {
     log.Fatalf("Failed to get components: %v", err)
 }
@@ -101,7 +105,8 @@ for _, resp := range componentsResp {
 ```go
 componentID := "component-uuid"
 
-component, err := client.GetComponent(componentID)
+ctx := context.Background()
+component, err := client.GetComponent(ctx, componentID)
 if err != nil {
     log.Fatalf("Failed to get component: %v", err)
 }
@@ -118,7 +123,8 @@ fmt.Printf("Created: %s\n", component.Component.CreatedAt)
 List and understand available component types:
 
 ```go
-typesResp, err := client.GetComponentTypes()
+ctx := context.Background()
+typesResp, err := client.GetComponentTypes(ctx)
 if err != nil {
     log.Fatalf("Failed to get types: %v", err)
 }
@@ -140,6 +146,7 @@ Analyze component versions across topics:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -155,7 +162,8 @@ func main() {
     )
 
     // Get all components
-    componentsResp, err := client.GetComponents()
+    ctx := context.Background()
+    componentsResp, err := client.GetComponents(ctx)
     if err != nil {
         log.Fatal(err)
     }
@@ -198,6 +206,7 @@ Analyze OpenShift versions in certification jobs:
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -212,7 +221,8 @@ func main() {
     )
 
     // Get recent jobs
-    jobsResp, err := client.GetJobs(30) // Last 30 days
+    ctx := context.Background()
+    jobsResp, err := client.GetJobs(ctx, 30) // Last 30 days
     if err != nil {
         log.Fatal(err)
     }
@@ -225,7 +235,7 @@ func main() {
             // Each job may have OCP version in components
             for _, compRef := range job.Components {
                 // Get component details
-                comp, err := client.GetComponent(compRef.ID)
+                comp, err := client.GetComponent(ctx, compRef.ID)
                 if err != nil {
                     continue
                 }
@@ -248,7 +258,9 @@ func main() {
 Create a new component (admin only):
 
 ```go
+ctx := context.Background()
 component, err := client.CreateComponent(
+    ctx,
     "My Component",      // name
     "ocp",              // type
     "topic-uuid",       // topic ID
@@ -266,7 +278,8 @@ fmt.Printf("Created component: %s\n", component.Component.ID)
 Update component metadata:
 
 ```go
-updated, err := client.UpdateComponent("component-uuid", lib.UpdateComponentRequest{
+ctx := context.Background()
+updated, err := client.UpdateComponent(ctx, "component-uuid", lib.UpdateComponentRequest{
     Name:    "Updated Name",
     Version: "4.15.1",
 })
@@ -282,7 +295,8 @@ fmt.Printf("Updated: %s v%s\n", updated.Component.Name, updated.Component.Versio
 Remove a component (admin only):
 
 ```go
-err := client.DeleteComponent("component-uuid")
+ctx := context.Background()
+err := client.DeleteComponent(ctx, "component-uuid")
 if err != nil {
     log.Fatalf("Failed to delete: %v", err)
 }
@@ -294,7 +308,8 @@ fmt.Println("Component deleted")
 ### Get a Specific Type
 
 ```go
-compType, err := client.GetComponentType("type-uuid")
+ctx := context.Background()
+compType, err := client.GetComponentType(ctx, "type-uuid")
 if err != nil {
     log.Fatal(err)
 }
@@ -304,7 +319,8 @@ fmt.Printf("Type: %s\n", compType.ComponentType.Name)
 ### Create a Type (Admin)
 
 ```go
-newType, err := client.CreateComponentType("my-custom-type")
+ctx := context.Background()
+newType, err := client.CreateComponentType(ctx, "my-custom-type")
 if err != nil {
     log.Fatal(err)
 }
@@ -314,7 +330,8 @@ fmt.Printf("Created type: %s\n", newType.ComponentType.Name)
 ### Update a Type
 
 ```go
-updated, err := client.UpdateComponentType("type-uuid", lib.UpdateComponentTypeRequest{
+ctx := context.Background()
+updated, err := client.UpdateComponentType(ctx, "type-uuid", lib.UpdateComponentTypeRequest{
     Name: "updated-name",
 })
 ```
@@ -322,7 +339,8 @@ updated, err := client.UpdateComponentType("type-uuid", lib.UpdateComponentTypeR
 ### Delete a Type
 
 ```go
-err := client.DeleteComponentType("type-uuid")
+ctx := context.Background()
+err := client.DeleteComponentType(ctx, "type-uuid")
 ```
 
 ## Practical Example: Find Latest Versions
@@ -331,6 +349,7 @@ err := client.DeleteComponentType("type-uuid")
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -346,8 +365,9 @@ func main() {
     )
 
     // Get components for a topic
+    ctx := context.Background()
     topicID := "your-topic-uuid"
-    componentsResp, err := client.GetTopicComponents(topicID)
+    componentsResp, err := client.GetTopicComponents(ctx, topicID)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
## Summary

Fixed all three tutorials in `docs/tutorials/` to include `context.Context` parameters in API call examples. The library API was updated in #125 to require context as the first parameter to all methods, but the tutorial documentation was not updated, making all code examples non-functional.

## Changes

Updated all code examples across three tutorial files:

- Added `"context"` import to all code examples
- Added `ctx := context.Background()` before API calls
- Updated all client method calls to pass `ctx` as first parameter

## Files Updated

- `docs/tutorials/01-getting-started.md` - 15 lines changed
- `docs/tutorials/02-certification-workflow.md` - 54 lines changed  
- `docs/tutorials/03-component-analysis.md` - 50 lines changed

## API Methods Fixed

All client methods now correctly show the context parameter:
- `GetIdentity(ctx)`
- `GetTopics(ctx)`
- `GetComponents(ctx)`
- `GetTopicComponents(ctx, topicID)`
- `CreateJob(ctx, ...)`
- `ScheduleJob(ctx, topicID)`
- `UpdateJobState(ctx, ...)`
- `UploadFile(ctx, ...)`
- `GetJob(ctx, jobID)`
- And all other component-related methods

## Related

- #125 - Original PR that added context.Context support to the library

## Test Plan

- [x] Verified all code examples compile correctly
- [x] Confirmed pattern matches actual library API signatures in `lib/client.go`
- [x] Checked consistency across all three tutorial files