### PR TITLE
Split linting and testing into parallel jobs

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   lint:
-    name: Run Linters and Vet
+    name: Run Linters
     runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
@@ -32,6 +32,21 @@ jobs:
 
       - name: Run go vet
         run: go vet ./...
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /bin/bash
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Run unit tests with coverage
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
## Summary

Split the monolithic lint job into separate linting and testing jobs to reduce CI time.

## Changes

- **lint** job runs golangci-lint and go vet
- **test** job runs unit tests with coverage and uploads to Codecov
- Both jobs run in parallel with swagger-alignment

## Expected Benefit

**Time savings: 20-40 seconds per run** - Linting and testing run in parallel instead of sequentially.

## Testing

The changes will be validated when CI runs on this PR.

## Related PRs

**Personal repos (sebrandon1):**
- bps-operator: https://github.com/sebrandon1/bps-operator/pull/115
- compliance-scripts: https://github.com/sebrandon1/compliance-scripts/pull/166
- ocp-doc-checker: https://github.com/sebrandon1/ocp-doc-checker/pull/57

**Organization repos (redhat-best-practices-for-k8s):**
- certsuite: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3748
- checks: https://github.com/redhat-best-practices-for-k8s/checks/pull/48
- checks-qe: https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/39
- operator-results-spreadsheet: https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/46