### PR TITLE
Add confirmation prompts for delete commands

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -167,6 +167,18 @@ var deleteComponentCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("component", deleteComponentIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -143,6 +143,19 @@ var deleteComponentTypeCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("component type", deleteComponentTypeIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -77,6 +77,19 @@ var deleteFileCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("file", deleteFileIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -114,6 +114,19 @@ var deleteJobCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("job", deleteJobIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -177,6 +177,19 @@ var deleteRemoteCICmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("remote CI", deleteRemoteCIIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,7 +18,36 @@ var rootCmd = &cobra.Command{
 	Version: Version,
 }
 
-var configFile string
+var (
+	configFile string
+	yesFlag    bool
+)
+
+// confirmDeletion prompts the user to confirm a deletion operation.
+// Returns true if the user confirms (or --yes flag is set), false otherwise.
+// Skips prompt if output format is JSON (assumes automation).
+func confirmDeletion(resourceType, resourceID string) (bool, error) {
+	// Skip prompt in JSON mode (automation)
+	if outputFormat == OutputFormatJSON {
+		return true, nil
+	}
+
+	// Skip prompt if --yes flag is set
+	if yesFlag {
+		return true, nil
+	}
+
+	// Interactive confirmation
+	fmt.Printf("Are you sure you want to delete %s '%s'? (yes/no): ", resourceType, resourceID)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "yes" || response == "y", nil
+}
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
@@ -27,6 +58,9 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Global --yes flag for delete operations
+	rootCmd.PersistentFlags().BoolVarP(&yesFlag, "yes", "y", false, "Skip confirmation prompts")
 }
 
 func initConfig() {

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -173,6 +173,19 @@ var deleteTeamCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("team", deleteTeamIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -155,6 +155,19 @@ var deleteTopicCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("topic", deleteTopicIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -201,6 +201,19 @@ var deleteUserCmd = &cobra.Command{
 			return fmt.Errorf("--id is required")
 		}
 
+		// Confirm deletion
+		confirmed, err := confirmDeletion("user", deleteUserIDFlag)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if outputFormat != OutputFormatJSON {
+				fmt.Println("Deletion canceled")
+			}
+			return nil
+		}
+
+
 		client := lib.NewClient(accessKey, secretKey)
 
 		if outputFormat != OutputFormatJSON {


### PR DESCRIPTION
## Summary

Adds interactive confirmation prompts to all delete commands to prevent accidental deletions.

Addresses brainstorm item #38: "Add confirmation prompts for delete commands"

## Changes

**New Features:**
- ✅ Interactive confirmation prompt for all delete operations
- ✅ Global `--yes`/`-y` flag to skip prompts (for scripting)
- ✅ Auto-skip in JSON mode (assumes automation)

**Updated Commands (8 total):**
- `delete-component`
- `delete-componenttype`
- `delete-file`
- `delete-job`
- `delete-remoteci`
- `delete-team`
- `delete-topic`
- `delete-user`

## Behavior

**Interactive Mode:**
```bash
$ dci delete-component --id abc123
Are you sure you want to delete component 'abc123'? (yes/no): yes
Deleting component: abc123
Component deleted successfully!
```

**Skip Confirmation (Scripting):**
```bash
$ dci delete-component --id abc123 --yes
Deleting component: abc123
Component deleted successfully!
```

**Cancelled Deletion:**
```bash
$ dci delete-team --id team-456
Are you sure you want to delete team 'team-456'? (yes/no): no
Deletion cancelled
```

## Implementation

- Added `confirmDeletion()` helper in `cmd/root.go`
- Added global `--yes` flag registered in root command
- Updated all 8 delete commands consistently

## Testing

- [x] Builds successfully
- [x] `--help` shows global `--yes` flag
- [x] All delete commands follow same pattern
- [x] Confirmation skipped in JSON mode
- [x] Confirmation skipped with `--yes` flag

## Related

- Part of UX improvements from brainstorm analysis
- First PR in Part B (UX improvements)
- Next PRs: --quiet/--verbose flags, required flag enforcement, --dry-run mode