### PR TITLE
feat: add UUID validation for resource IDs

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -11,23 +11,27 @@ import (
 
 // Variables for component command flags
 var (
-	getComponentIDFlag       string
-	createComponentName      string
-	createComponentType      string
-	createComponentTopicID   string
-	createComponentVersion   string
-	updateComponentIDFlag    string
-	updateComponentName      string
-	updateComponentState     string
-	updateComponentVersion   string
-	updateComponentTags      string
-	deleteComponentIDFlag    string
+	getComponentIDFlag     string
+	createComponentName    string
+	createComponentType    string
+	createComponentTopicID string
+	createComponentVersion string
+	updateComponentIDFlag  string
+	updateComponentName    string
+	updateComponentState   string
+	updateComponentVersion string
+	updateComponentTags    string
+	deleteComponentIDFlag  string
 )
 
 var getComponentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Get a specific component by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getComponentIDFlag, "component"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -90,6 +94,10 @@ var updateComponentCmd = &cobra.Command{
 	Use:   "update-component",
 	Short: "Update an existing component in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateComponentIDFlag, "component"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -142,6 +150,10 @@ var deleteComponentCmd = &cobra.Command{
 	Use:   "delete-component",
 	Short: "Delete a component from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteComponentIDFlag, "component"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -24,6 +24,10 @@ var getJobCmd = &cobra.Command{
 	Use:   "job",
 	Short: "Get a specific job by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getJobIDFlag, "job"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -52,6 +56,10 @@ var updateJobCmd = &cobra.Command{
 	Use:   "update-job",
 	Short: "Update an existing job in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateJobIDFlag, "job"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -98,6 +106,10 @@ var deleteJobCmd = &cobra.Command{
 	Use:   "delete-job",
 	Short: "Delete a job from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteJobIDFlag, "job"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -117,7 +129,6 @@ var deleteJobCmd = &cobra.Command{
 			printStatus("Deletion canceled")
 			return nil
 		}
-
 
 		client := lib.NewClient(accessKey, secretKey)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -46,6 +47,20 @@ func printVerbose(message string) {
 	if verboseFlag {
 		fmt.Printf("[VERBOSE] %s\n", message)
 	}
+}
+
+// validateResourceID validates that a resource ID is non-empty and matches the UUID format used by DCI.
+// Returns an error if validation fails.
+func validateResourceID(id, resourceType string) error {
+	if id == "" {
+		return fmt.Errorf("%s ID is required", resourceType)
+	}
+	// DCI uses UUIDs
+	uuidRegex := regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
+	if !uuidRegex.MatchString(id) {
+		return fmt.Errorf("invalid %s ID format (expected UUID): %s", resourceType, id)
+	}
+	return nil
 }
 
 // confirmDeletion prompts the user to confirm a deletion operation.

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -11,19 +11,23 @@ import (
 
 // Variables for topic command flags
 var (
-	getTopicIDFlag           string
-	createTopicName          string
-	createTopicProductID     string
+	getTopicIDFlag            string
+	createTopicName           string
+	createTopicProductID      string
 	createTopicComponentTypes string
-	updateTopicName          string
-	deleteTopicIDFlag        string
-	topicComponentsIDFlag    string
+	updateTopicName           string
+	deleteTopicIDFlag         string
+	topicComponentsIDFlag     string
 )
 
 var getTopicCmd = &cobra.Command{
 	Use:   "topic",
 	Short: "Get a specific topic by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getTopicIDFlag, "topic"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -134,6 +138,10 @@ var deleteTopicCmd = &cobra.Command{
 	Use:   "delete-topic",
 	Short: "Delete a topic from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteTopicIDFlag, "topic"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -153,7 +161,6 @@ var deleteTopicCmd = &cobra.Command{
 			printStatus("Deletion canceled")
 			return nil
 		}
-
 
 		client := lib.NewClient(accessKey, secretKey)
 


### PR DESCRIPTION
## Summary

Adds UUID format validation for resource IDs before making API calls.

**Changes:**
- Add `validateResourceID()` helper in cmd/root.go
- Validates UUID format: `[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`
- Apply validation to 8 commands across components, jobs, and topics

**Benefits:**
- Catch invalid IDs early with clear error messages
- Prevent unnecessary API calls with malformed IDs
- Better user experience