### PR TITLE
refactor: deduplicate date format constants in tests

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -471,7 +471,7 @@ func TestPrintTopicsJSON(t *testing.T) {
 }
 
 func TestCalculateDaysSince(t *testing.T) {
-	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02T15:04:05.999999")
+	yesterday := time.Now().Add(-24 * time.Hour).Format(dateFormat)
 	days := calculateDaysSince(yesterday)
 	assert.InDelta(t, 1.0, days, 0.5)
 }


### PR DESCRIPTION
## Summary

Eliminates duplicate date format string in test file.

**Changes:**
- Replace hardcoded `"2006-01-02T15:04:05.999999"` in `TestCalculateDaysSince` with `dateFormat` constant

**Benefits:**
- Single source of truth for date format
- Easier to maintain if format changes
- Follows DRY principle