### PR TITLE
docs: add common usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,62 @@ func main() {
 | [Tutorials](docs/tutorials/) | Step-by-step guides for common workflows |
 | [Examples](examples/) | Runnable example programs |
 
+## Common Usage Examples
+
+### Query Recent Jobs
+```bash
+# Get jobs from last 7 days
+go-dci jobs --age 7
+
+# Get jobs in specific date range
+go-dci jobs --start-date 2026-06-01 --end-date 2026-06-15
+
+# Get OCP version statistics
+go-dci ocpcount --age 30
+```
+
+### Work with Components
+```bash
+# List all components
+go-dci components
+
+# Filter by topic
+go-dci components --topic <topic-id>
+
+# Get specific component
+go-dci component --id <component-id>
+
+# Create a new component
+go-dci create-component --name "My Component" --type ocp --topic-id <topic-id> --version 4.15.0
+```
+
+### Manage Jobs
+```bash
+# Get specific job
+go-dci job --id <job-id>
+
+# Create a job
+go-dci create-job --topic-id <topic-id> --remoteci-id <remoteci-id>
+
+# Update job state
+go-dci update-job-state --job-id <job-id> --state success --comment "All tests passed"
+
+# Upload a file to a job
+go-dci upload-file --job-id <job-id> --file results.xml --mime-type application/xml
+```
+
+### File Operations
+```bash
+# List files for a job
+go-dci job-files --job-id <job-id>
+
+# Download a specific file
+go-dci file --id <file-id> --output downloaded-file.xml
+
+# Delete a file
+go-dci delete-file --id <file-id>
+```
+
 ## Supported DCI API Endpoints
 
 | Endpoint | CLI Commands |


### PR DESCRIPTION
## Summary

Adds practical CLI usage examples to README for common workflows.

**Changes:**
- Add "Common Usage Examples" section with:
  - Querying jobs (by age, date range, OCP stats)
  - Component workflows (list, filter, get, create)
  - Job management (get, create, update state, upload files)
  - File operations (list, download, delete)

**Benefits:**
- New users can quickly find common command patterns
- Reduces time to first successful command
- Shows real-world usage beyond basic `--help` output