### PR TITLE
fix: handle parse errors in calculateDaysSince

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -269,7 +269,10 @@ var getJobsCmd = &cobra.Command{
 				for _, c := range j.Components {
 					if strings.Contains(c.Name, "cnf-certification-test") || strings.Contains(c.Name, "certsuite") {
 						commit := extractCommitVersion(c.Name)
-						daysSince := calculateDaysSince(j.CreatedAt)
+						daysSince, err := calculateDaysSince(j.CreatedAt)
+						if err != nil {
+							return err
+						}
 						printStatus("Job ID: %s  -  Certsuite Version: %s (Days Since: %f)\n", j.ID, commit, daysSince)
 
 						jo := lib.JsonCertsuiteInfo{
@@ -383,9 +386,12 @@ func extractCommitVersion(componentName string) string {
 	return "unknown"
 }
 
-func calculateDaysSince(createdAt string) float64 {
-	createdTime, _ := time.Parse(dateFormat, createdAt)
-	return time.Since(createdTime).Hours() / 24
+func calculateDaysSince(createdAt string) (float64, error) {
+	createdTime, err := time.Parse(dateFormat, createdAt)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse timestamp '%s': %w", createdAt, err)
+	}
+	return time.Since(createdTime).Hours() / 24, nil
 }
 
 func printComponentsStdout(componentsResponses []lib.ComponentsResponse) {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -472,12 +472,14 @@ func TestPrintTopicsJSON(t *testing.T) {
 
 func TestCalculateDaysSince(t *testing.T) {
 	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02T15:04:05.999999")
-	days := calculateDaysSince(yesterday)
+	days, err := calculateDaysSince(yesterday)
+	assert.NoError(t, err)
 	assert.InDelta(t, 1.0, days, 0.5)
 }
 
 func TestCalculateDaysSince_InvalidTimestamp(t *testing.T) {
-	assert.NotPanics(t, func() {
-		calculateDaysSince("not-a-timestamp")
-	})
+	days, err := calculateDaysSince("not-a-timestamp")
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, days)
+	assert.Contains(t, err.Error(), "failed to parse timestamp")
 }


### PR DESCRIPTION
## Summary

Fix silent parse error in calculateDaysSince function.

## Changes

- Changed function signature from `func calculateDaysSince(createdAt string) float64` to `func calculateDaysSince(createdAt string) (float64, error)`
- Return error from time.Parse instead of ignoring it
- Updated call site to handle error properly
- Updated tests to verify error handling

## Testing

- All existing tests pass
- New test verifies error is returned for invalid timestamps
- make lint passes with 0 issues