### PR TITLE
feat: make OCP versions configurable via environment variable

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +27,7 @@ const (
 )
 
 var (
-	ocpVersionsToLookFor = []string{"4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20"}
+	ocpVersionsToLookFor = getOCPVersions()
 )
 
 var getTopicsCmd = &cobra.Command{
@@ -327,6 +328,26 @@ func getCredentials() (string, string, error) {
 		return "", "", errors.New("access key or secret key is not set")
 	}
 	return accessKey, secretKey, nil
+}
+
+// getOCPVersions reads the OCP_VERSIONS_TO_TRACK environment variable
+// and returns a slice of OCP versions to track. If the environment variable
+// is not set, it returns a default list of versions.
+func getOCPVersions() []string {
+	envVersions := os.Getenv("OCP_VERSIONS_TO_TRACK")
+	if envVersions == "" {
+		// Return default versions if environment variable is not set
+		return []string{"4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20"}
+	}
+
+	// Parse comma-separated list
+	versions := strings.Split(envVersions, ",")
+	// Trim whitespace from each version
+	for i, v := range versions {
+		versions[i] = strings.TrimSpace(v)
+	}
+
+	return versions
 }
 
 func countOcpVersions(jobsResponses []lib.JobsResponse) map[string]int {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -36,6 +36,22 @@ export GO_DCI_SECRETKEY=<your-secret-key>
 
 Environment variables take precedence over values in the config file.
 
+## Additional Configuration
+
+### OCP Version Tracking
+
+The `ocpcount` command tracks specific OCP versions by default. You can customize which versions to track using the `OCP_VERSIONS_TO_TRACK` environment variable:
+
+```bash
+export OCP_VERSIONS_TO_TRACK="4.15,4.16,4.17"
+```
+
+If not set, the following versions are tracked by default: 4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OCP_VERSIONS_TO_TRACK` | Comma-separated list of OCP versions to track in `ocpcount` command | 4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20 |
+
 ---
 
 Next: [CLI Reference](cli-reference.md)


### PR DESCRIPTION
## Summary

Make OCP version list configurable via `OCP_VERSIONS_TO_TRACK` environment variable.

## Changes

- Added `getOCPVersions()` function in `cmd/get.go` that reads the `OCP_VERSIONS_TO_TRACK` environment variable
- Parses comma-separated list and returns string slice with trimmed whitespace
- Defaults to `["4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20"]` if not set
- Updated `ocpVersionsToLookFor` initialization to call `getOCPVersions()`
- Added documentation in `docs/authentication.md` about the new environment variable

## Testing

- `make lint` passed with 0 issues
- `make test` passed all tests