### PR TITLE
feat: add friendly HTTP error messages

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -235,7 +235,8 @@ func (c *Client) GetIdentity(ctx context.Context) (*IdentityResponse, error) {
 	defer func() { _ = httpResponse.Body.Close() }()
 
 	if httpResponse.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("authentication failed with status code: %d", httpResponse.StatusCode)
+		body, _ := io.ReadAll(httpResponse.Body)
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var identity IdentityResponse
@@ -285,7 +286,7 @@ func (c *Client) GetComponentType(ctx context.Context, componentTypeID string) (
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get component type with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var componentType ComponentTypeResponse
@@ -317,7 +318,7 @@ func (c *Client) CreateComponentType(ctx context.Context, name string) (*Compone
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create component type with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ComponentTypeResponse
@@ -345,7 +346,7 @@ func (c *Client) UpdateComponentType(ctx context.Context, componentTypeID string
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update component type with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ComponentTypeResponse
@@ -368,7 +369,7 @@ func (c *Client) DeleteComponentType(ctx context.Context, componentTypeID string
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete component type with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -411,7 +412,7 @@ func (c *Client) GetTopic(ctx context.Context, topicID string) (*TopicResponse, 
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get topic with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var topic TopicResponse
@@ -444,7 +445,7 @@ func (c *Client) CreateTopic(ctx context.Context, name, productID string, compon
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create topic with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TopicResponse
@@ -472,7 +473,7 @@ func (c *Client) UpdateTopic(ctx context.Context, topicID string, updates Update
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update topic with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TopicResponse
@@ -495,7 +496,7 @@ func (c *Client) DeleteTopic(ctx context.Context, topicID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete topic with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -645,7 +646,7 @@ func (c *Client) GetJob(ctx context.Context, jobID string) (*JobResponse, error)
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get job with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var job JobResponse
@@ -673,7 +674,7 @@ func (c *Client) UpdateJob(ctx context.Context, jobID string, updates UpdateJobR
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update job with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response JobResponse
@@ -696,7 +697,7 @@ func (c *Client) DeleteJob(ctx context.Context, jobID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete job with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -723,7 +724,7 @@ func (c *Client) ScheduleJob(ctx context.Context, topicID string) (*CreateJobRes
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to schedule job with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response CreateJobResponse
@@ -746,7 +747,7 @@ func (c *Client) GetJobFiles(ctx context.Context, jobID string) (*FilesResponse,
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get job files with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response FilesResponse
@@ -801,7 +802,7 @@ func (c *Client) GetComponent(ctx context.Context, componentID string) (*Compone
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get component with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var component ComponentResponse
@@ -836,7 +837,7 @@ func (c *Client) CreateComponent(ctx context.Context, name, componentType, topic
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create component with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ComponentResponse
@@ -864,7 +865,7 @@ func (c *Client) UpdateComponent(ctx context.Context, componentID string, update
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update component with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ComponentResponse
@@ -887,7 +888,7 @@ func (c *Client) DeleteComponent(ctx context.Context, componentID string) error 
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete component with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -939,7 +940,7 @@ func (c *Client) CreateJob(ctx context.Context, topicID string, componentIDs []s
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create job with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response CreateJobResponse
@@ -973,7 +974,7 @@ func (c *Client) UpdateJobState(ctx context.Context, jobID string, status JobSta
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update job state with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response JobStateResponse
@@ -1002,7 +1003,7 @@ func (c *Client) fetchJobStates(ctx context.Context, jobID string, requestLimit,
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return JobStatesResponse{}, fmt.Errorf("failed to get job states with status code %d: %s", httpResponse.StatusCode, string(body))
+		return JobStatesResponse{}, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response JobStatesResponse
@@ -1036,7 +1037,7 @@ func (c *Client) GetFile(ctx context.Context, fileID string) ([]byte, string, er
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, "", fmt.Errorf("failed to get file with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, "", formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	content, err := io.ReadAll(httpResponse.Body)
@@ -1060,7 +1061,7 @@ func (c *Client) DeleteFile(ctx context.Context, fileID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete file with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -1102,7 +1103,7 @@ func (c *Client) uploadFileContent(ctx context.Context, reqURL string, content [
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to upload file with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response UploadFileResponse
@@ -1125,7 +1126,7 @@ func (c *Client) GetRemoteCIs(ctx context.Context) (*RemoteCIsResponse, error) {
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get remote CIs with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response RemoteCIsResponse
@@ -1148,7 +1149,7 @@ func (c *Client) GetRemoteCI(ctx context.Context, remoteciID string) (*RemoteCIR
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get remote CI with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response RemoteCIResponse
@@ -1181,7 +1182,7 @@ func (c *Client) CreateRemoteCI(ctx context.Context, name, teamID string) (*Remo
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create remote CI with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response RemoteCIResponse
@@ -1209,7 +1210,7 @@ func (c *Client) UpdateRemoteCI(ctx context.Context, remoteciID string, updates 
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update remote CI with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response RemoteCIResponse
@@ -1232,7 +1233,7 @@ func (c *Client) DeleteRemoteCI(ctx context.Context, remoteciID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete remote CI with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -1250,7 +1251,7 @@ func (c *Client) GetTeams(ctx context.Context) (*TeamsResponse, error) {
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get teams with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TeamsResponse
@@ -1273,7 +1274,7 @@ func (c *Client) GetTeam(ctx context.Context, teamID string) (*TeamResponse, err
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get team with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TeamResponse
@@ -1305,7 +1306,7 @@ func (c *Client) CreateTeam(ctx context.Context, name string) (*TeamResponse, er
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create team with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TeamResponse
@@ -1333,7 +1334,7 @@ func (c *Client) UpdateTeam(ctx context.Context, teamID string, updates UpdateTe
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update team with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response TeamResponse
@@ -1356,7 +1357,7 @@ func (c *Client) DeleteTeam(ctx context.Context, teamID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete team with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -1374,7 +1375,7 @@ func (c *Client) GetUsers(ctx context.Context) (*UsersResponse, error) {
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get users with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response UsersResponse
@@ -1397,7 +1398,7 @@ func (c *Client) GetUser(ctx context.Context, userID string) (*UserResponse, err
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get user with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response UserResponse
@@ -1433,7 +1434,7 @@ func (c *Client) CreateUser(ctx context.Context, name, email, fullname, teamID, 
 
 	if httpResponse.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to create user with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response UserResponse
@@ -1461,7 +1462,7 @@ func (c *Client) UpdateUser(ctx context.Context, userID string, updates UpdateUs
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to update user with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response UserResponse
@@ -1484,7 +1485,7 @@ func (c *Client) DeleteUser(ctx context.Context, userID string) error {
 
 	if httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return fmt.Errorf("failed to delete user with status code %d: %s", httpResponse.StatusCode, string(body))
+		return formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	return nil
@@ -1502,7 +1503,7 @@ func (c *Client) GetProducts(ctx context.Context) (*ProductsResponse, error) {
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get products with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ProductsResponse
@@ -1525,7 +1526,7 @@ func (c *Client) GetProduct(ctx context.Context, productID string) (*ProductResp
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, fmt.Errorf("failed to get product with status code %d: %s", httpResponse.StatusCode, string(body))
+		return nil, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ProductResponse

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -280,7 +280,7 @@ func TestGetIdentity_AuthenticationFailed(t *testing.T) {
 	identity, err := client.GetIdentity(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, identity)
-	assert.Contains(t, err.Error(), "authentication failed")
+	assert.Contains(t, err.Error(), "Authentication failed")
 }
 
 func TestGetIdentity_InvalidJSON(t *testing.T) {
@@ -509,7 +509,7 @@ func TestCreateJob_Error(t *testing.T) {
 	response, err := client.CreateJob(context.Background(), "invalid-topic", nil, "")
 	assert.Error(t, err)
 	assert.Nil(t, response)
-	assert.Contains(t, err.Error(), "failed to create job")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateJobState_Success(t *testing.T) {
@@ -610,7 +610,7 @@ func TestUpdateJobState_Error(t *testing.T) {
 	response, err := client.UpdateJobState(context.Background(), "nonexistent-job", JobStateRunning, "")
 	assert.Error(t, err)
 	assert.Nil(t, response)
-	assert.Contains(t, err.Error(), "failed to update job state")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUploadFileContent_Success(t *testing.T) {
@@ -661,7 +661,7 @@ func TestUploadFileContent_Error(t *testing.T) {
 	response, err := client.UploadFileContent(context.Background(), "invalid-job", "test.xml", "application/junit", []byte("content"))
 	assert.Error(t, err)
 	assert.Nil(t, response)
-	assert.Contains(t, err.Error(), "failed to upload file")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateJobRequest_Struct(t *testing.T) {
@@ -786,7 +786,7 @@ func TestGetTopic_Error(t *testing.T) {
 	result, err := client.GetTopic(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get topic")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateTopic_Success(t *testing.T) {
@@ -828,7 +828,7 @@ func TestCreateTopic_Error(t *testing.T) {
 	result, err := client.CreateTopic(context.Background(), "bad", "bad", nil)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create topic")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateTopic_Success(t *testing.T) {
@@ -862,7 +862,7 @@ func TestUpdateTopic_Error(t *testing.T) {
 	result, err := client.UpdateTopic(context.Background(), "nonexistent", UpdateTopicRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update topic")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteTopic_Success(t *testing.T) {
@@ -889,7 +889,7 @@ func TestDeleteTopic_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteTopic(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete topic")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetTopicComponents_Success(t *testing.T) {
@@ -1154,7 +1154,7 @@ func TestGetJob_Error(t *testing.T) {
 	result, err := client.GetJob(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get job")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateJob_Success(t *testing.T) {
@@ -1188,7 +1188,7 @@ func TestUpdateJob_Error(t *testing.T) {
 	result, err := client.UpdateJob(context.Background(), "nonexistent", UpdateJobRequest{Comment: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update job")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteJob_Success(t *testing.T) {
@@ -1215,7 +1215,7 @@ func TestDeleteJob_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteJob(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete job")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestScheduleJob_Success(t *testing.T) {
@@ -1256,7 +1256,7 @@ func TestScheduleJob_Error(t *testing.T) {
 	result, err := client.ScheduleJob(context.Background(), "bad-topic")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to schedule job")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetJobFiles_Success(t *testing.T) {
@@ -1297,7 +1297,7 @@ func TestGetJobFiles_Error(t *testing.T) {
 	result, err := client.GetJobFiles(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get job files")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetJobStates_WithJobID_Success(t *testing.T) {
@@ -1364,7 +1364,7 @@ func TestGetJobStates_Error(t *testing.T) {
 	result, err := client.GetJobStates(context.Background(), "job-123")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get job states")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestFetchJobs_Success(t *testing.T) {
@@ -1444,7 +1444,7 @@ func TestGetComponent_Error(t *testing.T) {
 	result, err := client.GetComponent(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get component")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateComponent_Success(t *testing.T) {
@@ -1487,7 +1487,7 @@ func TestCreateComponent_Error(t *testing.T) {
 	result, err := client.CreateComponent(context.Background(), "bad", "bad", "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create component")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateComponent_Success(t *testing.T) {
@@ -1521,7 +1521,7 @@ func TestUpdateComponent_Error(t *testing.T) {
 	result, err := client.UpdateComponent(context.Background(), "nonexistent", UpdateComponentRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update component")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteComponent_Success(t *testing.T) {
@@ -1548,7 +1548,7 @@ func TestDeleteComponent_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteComponent(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete component")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetComponentType_Success(t *testing.T) {
@@ -1583,7 +1583,7 @@ func TestGetComponentType_Error(t *testing.T) {
 	result, err := client.GetComponentType(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get component type")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateComponentType_Success(t *testing.T) {
@@ -1618,7 +1618,7 @@ func TestCreateComponentType_Error(t *testing.T) {
 	result, err := client.CreateComponentType(context.Background(), "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create component type")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateComponentType_Success(t *testing.T) {
@@ -1652,7 +1652,7 @@ func TestUpdateComponentType_Error(t *testing.T) {
 	result, err := client.UpdateComponentType(context.Background(), "nonexistent", UpdateComponentTypeRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update component type")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteComponentType_Success(t *testing.T) {
@@ -1679,7 +1679,7 @@ func TestDeleteComponentType_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteComponentType(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete component type")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetRemoteCIs_Success(t *testing.T) {
@@ -1720,7 +1720,7 @@ func TestGetRemoteCIs_Error(t *testing.T) {
 	result, err := client.GetRemoteCIs(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get remote CIs")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetRemoteCI_Success(t *testing.T) {
@@ -1755,7 +1755,7 @@ func TestGetRemoteCI_Error(t *testing.T) {
 	result, err := client.GetRemoteCI(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get remote CI")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateRemoteCI_Success(t *testing.T) {
@@ -1796,7 +1796,7 @@ func TestCreateRemoteCI_Error(t *testing.T) {
 	result, err := client.CreateRemoteCI(context.Background(), "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create remote CI")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateRemoteCI_Success(t *testing.T) {
@@ -1830,7 +1830,7 @@ func TestUpdateRemoteCI_Error(t *testing.T) {
 	result, err := client.UpdateRemoteCI(context.Background(), "nonexistent", UpdateRemoteCIRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update remote CI")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteRemoteCI_Success(t *testing.T) {
@@ -1857,7 +1857,7 @@ func TestDeleteRemoteCI_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteRemoteCI(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete remote CI")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetTeams_Success(t *testing.T) {
@@ -1899,7 +1899,7 @@ func TestGetTeams_Error(t *testing.T) {
 	result, err := client.GetTeams(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get teams")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetTeam_Success(t *testing.T) {
@@ -1934,7 +1934,7 @@ func TestGetTeam_Error(t *testing.T) {
 	result, err := client.GetTeam(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get team")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateTeam_Success(t *testing.T) {
@@ -1974,7 +1974,7 @@ func TestCreateTeam_Error(t *testing.T) {
 	result, err := client.CreateTeam(context.Background(), "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create team")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateTeam_Success(t *testing.T) {
@@ -2008,7 +2008,7 @@ func TestUpdateTeam_Error(t *testing.T) {
 	result, err := client.UpdateTeam(context.Background(), "nonexistent", UpdateTeamRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update team")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteTeam_Success(t *testing.T) {
@@ -2035,7 +2035,7 @@ func TestDeleteTeam_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteTeam(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete team")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetUsers_Success(t *testing.T) {
@@ -2077,7 +2077,7 @@ func TestGetUsers_Error(t *testing.T) {
 	result, err := client.GetUsers(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get users")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetUser_Success(t *testing.T) {
@@ -2112,7 +2112,7 @@ func TestGetUser_Error(t *testing.T) {
 	result, err := client.GetUser(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get user")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestCreateUser_Success(t *testing.T) {
@@ -2155,7 +2155,7 @@ func TestCreateUser_Error(t *testing.T) {
 	result, err := client.CreateUser(context.Background(), "bad", "bad", "bad", "bad", "bad")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to create user")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUpdateUser_Success(t *testing.T) {
@@ -2189,7 +2189,7 @@ func TestUpdateUser_Error(t *testing.T) {
 	result, err := client.UpdateUser(context.Background(), "nonexistent", UpdateUserRequest{Name: "x"})
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to update user")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteUser_Success(t *testing.T) {
@@ -2216,7 +2216,7 @@ func TestDeleteUser_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteUser(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete user")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetProducts_Success(t *testing.T) {
@@ -2258,7 +2258,7 @@ func TestGetProducts_Error(t *testing.T) {
 	result, err := client.GetProducts(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get products")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetProduct_Success(t *testing.T) {
@@ -2293,7 +2293,7 @@ func TestGetProduct_Error(t *testing.T) {
 	result, err := client.GetProduct(context.Background(), "nonexistent")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to get product")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestGetFile_Success(t *testing.T) {
@@ -2330,7 +2330,7 @@ func TestGetFile_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, content)
 	assert.Empty(t, contentType)
-	assert.Contains(t, err.Error(), "failed to get file")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDeleteFile_Success(t *testing.T) {
@@ -2357,7 +2357,7 @@ func TestDeleteFile_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	err := client.DeleteFile(context.Background(), "nonexistent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete file")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestUploadFile_Success(t *testing.T) {
@@ -2420,7 +2420,7 @@ func TestUploadFile_Error(t *testing.T) {
 	result, err := client.UploadFile(context.Background(), "bad-job", filePath, "application/xml")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to upload file")
+	assert.Contains(t, err.Error(), "HTTP")
 }
 
 func TestDoRequest_RetryOn500(t *testing.T) {

--- a/lib/http_error.go
+++ b/lib/http_error.go
@@ -1,0 +1,46 @@
+package lib
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// formatHTTPError returns a user-friendly error message with actionable guidance
+// based on the HTTP status code and response body.
+func formatHTTPError(statusCode int, body []byte) error {
+	baseMsg := fmt.Sprintf("HTTP %d: %s", statusCode, http.StatusText(statusCode))
+
+	var guidance string
+	switch statusCode {
+	case http.StatusUnauthorized:
+		guidance = "Authentication failed. Please check your DCI credentials:\n" +
+			"  - Verify your access key and secret key are correct\n" +
+			"  - Run: go-dci config set --accesskey <key> --secretkey <secret>\n" +
+			"  - Or set environment variables: GO_DCI_ACCESSKEY and GO_DCI_SECRETKEY"
+	case http.StatusForbidden:
+		guidance = "Permission denied. Your credentials are valid but lack permission for this resource:\n" +
+			"  - Contact your DCI administrator to request access\n" +
+			"  - Verify you're using the correct team/project credentials"
+	case http.StatusNotFound:
+		guidance = "Resource not found. The requested item does not exist:\n" +
+			"  - Check the resource ID/name is correct\n" +
+			"  - Verify the resource hasn't been deleted\n" +
+			"  - Use list commands to see available resources"
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable:
+		guidance = "DCI server error. This is a temporary issue:\n" +
+			"  - Try again in a few moments\n" +
+			"  - Check DCI service status\n" +
+			"  - Contact support if the issue persists"
+	default:
+		guidance = "An unexpected error occurred"
+	}
+
+	msg := fmt.Sprintf("%s\n%s", baseMsg, guidance)
+
+	// Include response body if present and not too large
+	if len(body) > 0 && len(body) < 500 {
+		msg += fmt.Sprintf("\n\nServer response: %s", string(body))
+	}
+
+	return fmt.Errorf("%s", msg)
+}


### PR DESCRIPTION
Add user-friendly HTTP error messages with actionable guidance for common status codes.

## Changes

- Created `lib/http_error.go` with `formatHTTPError()` function
- Updated all HTTP error handling in `lib/client.go` to use friendly error messages
- Added actionable guidance for common status codes:
  - 401: Check credentials and configuration
  - 403: Contact admin for permissions
  - 404: Verify resource exists
  - 500/502/503: Server errors, retry later
- Updated tests to validate new error message format

## Benefits

Users now receive clear, actionable error messages instead of generic HTTP status codes when API requests fail.