### PR TITLE
fix: add missing validateResourceID calls to all ID-accepting commands

### DIFF
--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -22,6 +22,10 @@ var getComponentTypeCmd = &cobra.Command{
 	Use:   "componenttype",
 	Short: "Get a specific component type by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getComponentTypeIDFlag, "component type"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -84,6 +88,10 @@ var updateComponentTypeCmd = &cobra.Command{
 	Use:   "update-componenttype",
 	Short: "Update an existing component type in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateComponentTypeIDFlag, "component type"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -126,6 +134,10 @@ var deleteComponentTypeCmd = &cobra.Command{
 	Use:   "delete-componenttype",
 	Short: "Delete a component type from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteComponentTypeIDFlag, "component type"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -20,6 +20,10 @@ var getFileCmd = &cobra.Command{
 	Use:   "file",
 	Short: "Download a file by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getFileIDFlag, "file"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -62,6 +66,10 @@ var deleteFileCmd = &cobra.Command{
 	Use:   "delete-file",
 	Short: "Delete a file from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteFileIDFlag, "file"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/filesCmd_test.go
+++ b/cmd/filesCmd_test.go
@@ -42,6 +42,9 @@ func TestDeleteFileCmd_MissingID(t *testing.T) {
 func TestGetFileCmd_MissingCredentials(t *testing.T) {
 	viper.Reset()
 
+	getFileIDFlag = "550e8400-e29b-41d4-a716-446655440000"
+	defer func() { getFileIDFlag = "" }()
+
 	cmd := &cobra.Command{}
 	err := getFileCmd.RunE(cmd, []string{})
 	assert.Error(t, err)
@@ -50,6 +53,9 @@ func TestGetFileCmd_MissingCredentials(t *testing.T) {
 
 func TestDeleteFileCmd_MissingCredentials(t *testing.T) {
 	viper.Reset()
+
+	deleteFileIDFlag = "550e8400-e29b-41d4-a716-446655440000"
+	defer func() { deleteFileIDFlag = "" }()
 
 	cmd := &cobra.Command{}
 	err := deleteFileCmd.RunE(cmd, []string{})

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -155,6 +155,10 @@ var scheduleJobCmd = &cobra.Command{
 	Use:   "schedule-job",
 	Short: "Schedule a job with auto-selected components",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(scheduleJobTopicID, "topic"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -189,6 +193,10 @@ var getJobFilesCmd = &cobra.Command{
 	Use:   "job-files",
 	Short: "Get all files for a specific job",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(jobFilesIDFlag, "job"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -17,6 +17,12 @@ var getJobStatesCmd = &cobra.Command{
 	Use:   "jobstates",
 	Short: "Get job states, optionally filtered by job ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if getJobStatesJobIDFlag != "" {
+			if err := validateResourceID(getJobStatesJobIDFlag, "job"); err != nil {
+				return err
+			}
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -68,6 +68,10 @@ var updateJobStateCmd = &cobra.Command{
 	Use:   "update-job-state",
 	Short: "Update the state of a job (pre-run, running, success, failure, etc.)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateJobStateJobID, "job"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -45,6 +45,10 @@ var getProductCmd = &cobra.Command{
 	Use:   "product",
 	Short: "Get a specific product by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getProductIDFlag, "product"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -51,6 +51,10 @@ var getRemoteCICmd = &cobra.Command{
 	Use:   "remoteci",
 	Short: "Get a specific remote CI by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getRemoteCIsCmd_IDFlag, "remote CI"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -113,6 +117,10 @@ var updateRemoteCICmd = &cobra.Command{
 	Use:   "update-remoteci",
 	Short: "Update an existing remote CI in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateRemoteCIIDFlag, "remote CI"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -155,6 +163,10 @@ var deleteRemoteCICmd = &cobra.Command{
 	Use:   "delete-remoteci",
 	Short: "Delete a remote CI from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteRemoteCIIDFlag, "remote CI"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -55,6 +55,10 @@ var getTeamCmd = &cobra.Command{
 	Use:   "team",
 	Short: "Get a specific team by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getTeamIDFlag, "team"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -117,6 +121,10 @@ var updateTeamCmd = &cobra.Command{
 	Use:   "update-team",
 	Short: "Update an existing team in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateTeamIDFlag, "team"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -159,6 +167,10 @@ var deleteTeamCmd = &cobra.Command{
 	Use:   "delete-team",
 	Short: "Delete a team from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteTeamIDFlag, "team"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -192,6 +192,10 @@ var getTopicComponentsCmd = &cobra.Command{
 	Use:   "topic-components",
 	Short: "Get all components for a specific topic",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(topicComponentsIDFlag, "topic"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -61,6 +61,10 @@ var getUserCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Get a specific user by ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(getUserIDFlag, "user"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -130,6 +134,10 @@ var updateUserCmd = &cobra.Command{
 	Use:   "update-user",
 	Short: "Update an existing user in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(updateUserIDFlag, "user"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err
@@ -178,6 +186,10 @@ var deleteUserCmd = &cobra.Command{
 	Use:   "delete-user",
 	Short: "Delete a user from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateResourceID(deleteUserIDFlag, "user"); err != nil {
+			return err
+		}
+
 		accessKey, secretKey, err := getCredentials()
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

- Added validateResourceID calls to 19 commands that accept resource IDs but were not validating them
- Commands now reject empty or malformed UUIDs before making API calls, giving clear error messages instead of confusing API 404s
- Follows the same pattern used by topic, job, and component commands
- Updated 2 test cases in filesCmd_test.go that expected credential errors but now correctly hit validation first

Affected commands: topic-components, schedule-job, job-files, remoteci, update-remoteci, delete-remoteci, team, update-team, delete-team, user, update-user, delete-user, componenttype, update-componenttype, delete-componenttype, file, delete-file, product, update-job-state, jobstates

Fixes #175