### PR TITLE
fix: paginate GetRemoteCIs and GetProducts to fetch all results

### DIFF
--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -26,16 +26,16 @@ var getProductsCmd = &cobra.Command{
 
 		printStatus("Getting products...")
 
-		response, err := client.GetProducts(cmd.Context())
+		responses, err := client.GetProducts(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get products: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
-			return printProductsJSON(response)
+			return printProductsJSON(responses)
 		}
 
-		printProductsStdout(response)
+		printProductsStdout(responses)
 
 		return nil
 	},
@@ -73,21 +73,34 @@ var getProductCmd = &cobra.Command{
 	},
 }
 
-func printProductsStdout(response *lib.ProductsResponse) {
-	if len(response.Products) == 0 {
+func printProductsStdout(responses []lib.ProductsResponse) {
+	total := 0
+	for _, resp := range responses {
+		total += len(resp.Products)
+	}
+	if total == 0 {
 		fmt.Println("No products found.")
 		return
 	}
 	fmt.Println("---")
-	for _, product := range response.Products {
-		fmt.Printf("ID: %s | Name: %s | Label: %s | State: %s\n",
-			product.ID, product.Name, product.Label, product.State)
+	for _, resp := range responses {
+		for _, product := range resp.Products {
+			fmt.Printf("ID: %s | Name: %s | Label: %s | State: %s\n",
+				product.ID, product.Name, product.Label, product.State)
+		}
 	}
-	fmt.Printf("Total Products: %d\n", len(response.Products))
+	fmt.Printf("Total Products: %d\n", total)
 }
 
-func printProductsJSON(response *lib.ProductsResponse) error {
-	jsonBytes, err := json.Marshal(response)
+func printProductsJSON(responses []lib.ProductsResponse) error {
+	var all []lib.Product
+	for _, resp := range responses {
+		all = append(all, resp.Products...)
+	}
+	jsonBytes, err := json.Marshal(map[string]any{
+		"products": all,
+		"total":    len(all),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}

--- a/cmd/productsCmd_test.go
+++ b/cmd/productsCmd_test.go
@@ -8,61 +8,68 @@ import (
 )
 
 func TestPrintProductsStdout(t *testing.T) {
-	response := &lib.ProductsResponse{
-		Meta: lib.Meta{Count: 2},
-		Products: []lib.Product{
-			{
-				ID:          "product-abc-123",
-				Name:        "Red Hat OpenShift Container Platform",
-				Label:       "RHOCP",
-				Description: "Enterprise Kubernetes platform",
-				State:       "active",
-				CreatedAt:   "2024-01-15T10:30:00.000000",
-				UpdatedAt:   "2024-06-20T14:45:00.000000",
-			},
-			{
-				ID:          "product-def-456",
-				Name:        "Red Hat Enterprise Linux",
-				Label:       "RHEL",
-				Description: "Enterprise Linux distribution",
-				State:       "active",
-				CreatedAt:   "2024-02-01T08:00:00.000000",
-				UpdatedAt:   "2024-07-10T12:00:00.000000",
+	responses := []lib.ProductsResponse{
+		{
+			Meta: lib.Meta{Count: 2},
+			Products: []lib.Product{
+				{
+					ID:          "product-abc-123",
+					Name:        "Red Hat OpenShift Container Platform",
+					Label:       "RHOCP",
+					Description: "Enterprise Kubernetes platform",
+					State:       "active",
+					CreatedAt:   "2024-01-15T10:30:00.000000",
+					UpdatedAt:   "2024-06-20T14:45:00.000000",
+				},
+				{
+					ID:          "product-def-456",
+					Name:        "Red Hat Enterprise Linux",
+					Label:       "RHEL",
+					Description: "Enterprise Linux distribution",
+					State:       "active",
+					CreatedAt:   "2024-02-01T08:00:00.000000",
+					UpdatedAt:   "2024-07-10T12:00:00.000000",
+				},
 			},
 		},
 	}
 
 	assert.NotPanics(t, func() {
-		printProductsStdout(response)
+		printProductsStdout(responses)
 	})
 }
 
 func TestPrintProductsStdout_Empty(t *testing.T) {
-	response := &lib.ProductsResponse{
-		Meta:     lib.Meta{Count: 0},
-		Products: []lib.Product{},
+	responses := []lib.ProductsResponse{
+		{
+			Meta:     lib.Meta{Count: 0},
+			Products: []lib.Product{},
+		},
 	}
 
 	assert.NotPanics(t, func() {
-		printProductsStdout(response)
+		printProductsStdout(responses)
 	})
 }
 
 func TestPrintProductsJSON(t *testing.T) {
-	response := &lib.ProductsResponse{
-		Meta: lib.Meta{Count: 1},
-		Products: []lib.Product{
-			{
-				ID:    "product-abc-123",
-				Name:  "Red Hat OpenShift Container Platform",
-				Label: "RHOCP",
-				State: "active",
+	responses := []lib.ProductsResponse{
+		{
+			Meta: lib.Meta{Count: 1},
+			Products: []lib.Product{
+				{
+					ID:    "product-abc-123",
+					Name:  "Red Hat OpenShift Container Platform",
+					Label: "RHOCP",
+					State: "active",
+				},
 			},
 		},
 	}
 
 	assert.NotPanics(t, func() {
-		printProductsJSON(response)
+		err := printProductsJSON(responses)
+		assert.NoError(t, err)
 	})
 }
 
@@ -98,6 +105,7 @@ func TestPrintProductJSON(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		printProductJSON(response)
+		err := printProductJSON(response)
+		assert.NoError(t, err)
 	})
 }

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -32,16 +32,16 @@ var getRemoteCIsCmd = &cobra.Command{
 
 		printStatus("Getting remote CIs...")
 
-		response, err := client.GetRemoteCIs(cmd.Context())
+		responses, err := client.GetRemoteCIs(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get remote CIs: %v", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
-			return printRemoteCIsJSON(response)
+			return printRemoteCIsJSON(responses)
 		}
 
-		printRemoteCIsStdout(response)
+		printRemoteCIsStdout(responses)
 
 		return nil
 	},
@@ -209,21 +209,34 @@ var deleteRemoteCICmd = &cobra.Command{
 	},
 }
 
-func printRemoteCIsStdout(response *lib.RemoteCIsResponse) {
-	if len(response.RemoteCIs) == 0 {
+func printRemoteCIsStdout(responses []lib.RemoteCIsResponse) {
+	total := 0
+	for _, resp := range responses {
+		total += len(resp.RemoteCIs)
+	}
+	if total == 0 {
 		fmt.Println("No remote CIs found.")
 		return
 	}
 	fmt.Println("---")
-	for _, rci := range response.RemoteCIs {
-		fmt.Printf("ID: %s | Name: %s | Team ID: %s | State: %s\n",
-			rci.ID, rci.Name, rci.TeamID, rci.State)
+	for _, resp := range responses {
+		for _, rci := range resp.RemoteCIs {
+			fmt.Printf("ID: %s | Name: %s | Team ID: %s | State: %s\n",
+				rci.ID, rci.Name, rci.TeamID, rci.State)
+		}
 	}
-	fmt.Printf("Total Remote CIs: %d\n", len(response.RemoteCIs))
+	fmt.Printf("Total Remote CIs: %d\n", total)
 }
 
-func printRemoteCIsJSON(response *lib.RemoteCIsResponse) error {
-	jsonBytes, err := json.Marshal(response)
+func printRemoteCIsJSON(responses []lib.RemoteCIsResponse) error {
+	var all []lib.RemoteCI
+	for _, resp := range responses {
+		all = append(all, resp.RemoteCIs...)
+	}
+	jsonBytes, err := json.Marshal(map[string]any{
+		"remotecis": all,
+		"total":     len(all),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}

--- a/cmd/remotecisCmd_test.go
+++ b/cmd/remotecisCmd_test.go
@@ -8,59 +8,66 @@ import (
 )
 
 func TestPrintRemoteCIsStdout(t *testing.T) {
-	response := &lib.RemoteCIsResponse{
-		Meta: lib.Meta{Count: 2},
-		RemoteCIs: []lib.RemoteCI{
-			{
-				ID:        "remoteci-abc-123",
-				Name:      "partner-lab-remoteci",
-				TeamID:    "team-456",
-				State:     "active",
-				CreatedAt: "2024-03-10T09:00:00.000000",
-				UpdatedAt: "2024-08-15T16:30:00.000000",
-			},
-			{
-				ID:        "remoteci-def-789",
-				Name:      "staging-remoteci",
-				TeamID:    "team-012",
-				State:     "active",
-				CreatedAt: "2024-04-20T11:15:00.000000",
-				UpdatedAt: "2024-09-01T08:45:00.000000",
+	responses := []lib.RemoteCIsResponse{
+		{
+			Meta: lib.Meta{Count: 2},
+			RemoteCIs: []lib.RemoteCI{
+				{
+					ID:        "remoteci-abc-123",
+					Name:      "partner-lab-remoteci",
+					TeamID:    "team-456",
+					State:     "active",
+					CreatedAt: "2024-03-10T09:00:00.000000",
+					UpdatedAt: "2024-08-15T16:30:00.000000",
+				},
+				{
+					ID:        "remoteci-def-789",
+					Name:      "staging-remoteci",
+					TeamID:    "team-012",
+					State:     "active",
+					CreatedAt: "2024-04-20T11:15:00.000000",
+					UpdatedAt: "2024-09-01T08:45:00.000000",
+				},
 			},
 		},
 	}
 
 	assert.NotPanics(t, func() {
-		printRemoteCIsStdout(response)
+		printRemoteCIsStdout(responses)
 	})
 }
 
 func TestPrintRemoteCIsStdout_Empty(t *testing.T) {
-	response := &lib.RemoteCIsResponse{
-		Meta:      lib.Meta{Count: 0},
-		RemoteCIs: []lib.RemoteCI{},
+	responses := []lib.RemoteCIsResponse{
+		{
+			Meta:      lib.Meta{Count: 0},
+			RemoteCIs: []lib.RemoteCI{},
+		},
 	}
 
 	assert.NotPanics(t, func() {
-		printRemoteCIsStdout(response)
+		printRemoteCIsStdout(responses)
 	})
 }
 
 func TestPrintRemoteCIsJSON(t *testing.T) {
-	response := &lib.RemoteCIsResponse{
-		Meta: lib.Meta{Count: 1},
-		RemoteCIs: []lib.RemoteCI{
-			{
-				ID:     "remoteci-abc-123",
-				Name:   "partner-lab-remoteci",
-				TeamID: "team-456",
-				State:  "active",
+	responses := []lib.RemoteCIsResponse{
+		{
+			Meta: lib.Meta{Count: 1},
+			RemoteCIs: []lib.RemoteCI{
+				{
+					ID:     "remoteci-abc-123",
+					Name:   "partner-lab-remoteci",
+					TeamID: "team-456",
+					State:  "active",
+				},
 			},
 		},
 	}
 
 	assert.NotPanics(t, func() {
-		printRemoteCIsJSON(response)
+		err := printRemoteCIsJSON(responses)
+		assert.NoError(t, err)
 	})
 }
 
@@ -94,6 +101,7 @@ func TestPrintRemoteCIJSON(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		printRemoteCIJSON(response)
+		err := printRemoteCIJSON(response)
+		assert.NoError(t, err)
 	})
 }

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -121,11 +121,19 @@ func main() {
 	products, err := client.GetProducts(context.Background())
 	if err != nil {
 		log.Printf("   Could not get products: %v\n", err)
-	} else if len(products.Products) == 0 {
-		fmt.Println("   No products found")
 	} else {
-		for _, product := range products.Products {
-			fmt.Printf("   - %s (ID: %s)\n", product.Name, product.ID[:8]+"...")
+		total := 0
+		for _, resp := range products {
+			total += len(resp.Products)
+		}
+		if total == 0 {
+			fmt.Println("   No products found")
+		} else {
+			for _, resp := range products {
+				for _, product := range resp.Products {
+					fmt.Printf("   - %s (ID: %s)\n", product.Name, product.ID[:8]+"...")
+				}
+			}
 		}
 	}
 

--- a/lib/client.go
+++ b/lib/client.go
@@ -1144,26 +1144,33 @@ func (c *Client) uploadFileContent(ctx context.Context, reqURL string, content [
 }
 
 // GetRemoteCIs retrieves all remote CIs from DCI
-func (c *Client) GetRemoteCIs(ctx context.Context) (*RemoteCIsResponse, error) {
-	reqURL := fmt.Sprintf("%s/remotecis", c.BaseURL)
+func (c *Client) GetRemoteCIs(ctx context.Context) ([]RemoteCIsResponse, error) {
+	return paginate(ctx, func(limit, offset int) (RemoteCIsResponse, int, error) {
+		resp, err := c.fetchRemoteCIs(ctx, limit, offset)
+		return resp, len(resp.RemoteCIs), err
+	})
+}
+
+func (c *Client) fetchRemoteCIs(ctx context.Context, requestLimit, offset int) (RemoteCIsResponse, error) {
+	reqURL := paginatedURL(c.BaseURL+"/remotecis", requestLimit, offset)
 	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error getting remote CIs: %w", err)
+		return RemoteCIsResponse{}, fmt.Errorf("error getting remote CIs: %w", err)
 	}
 
 	defer func() { _ = httpResponse.Body.Close() }()
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, formatHTTPError(httpResponse.StatusCode, body)
+		return RemoteCIsResponse{}, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response RemoteCIsResponse
 	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("error decoding response: %w", err)
+		return RemoteCIsResponse{}, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return &response, nil
+	return response, nil
 }
 
 // GetRemoteCI retrieves a specific remote CI by ID
@@ -1549,26 +1556,33 @@ func (c *Client) DeleteUser(ctx context.Context, userID string) error {
 }
 
 // GetProducts retrieves all products from DCI
-func (c *Client) GetProducts(ctx context.Context) (*ProductsResponse, error) {
-	reqURL := fmt.Sprintf("%s/products", c.BaseURL)
+func (c *Client) GetProducts(ctx context.Context) ([]ProductsResponse, error) {
+	return paginate(ctx, func(limit, offset int) (ProductsResponse, int, error) {
+		resp, err := c.fetchProducts(ctx, limit, offset)
+		return resp, len(resp.Products), err
+	})
+}
+
+func (c *Client) fetchProducts(ctx context.Context, requestLimit, offset int) (ProductsResponse, error) {
+	reqURL := paginatedURL(c.BaseURL+"/products", requestLimit, offset)
 	httpResponse, err := c.doRequest(ctx, http.MethodGet, reqURL, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error getting products: %w", err)
+		return ProductsResponse{}, fmt.Errorf("error getting products: %w", err)
 	}
 
 	defer func() { _ = httpResponse.Body.Close() }()
 
 	if httpResponse.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResponse.Body)
-		return nil, formatHTTPError(httpResponse.StatusCode, body)
+		return ProductsResponse{}, formatHTTPError(httpResponse.StatusCode, body)
 	}
 
 	var response ProductsResponse
 	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("error decoding response: %w", err)
+		return ProductsResponse{}, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return &response, nil
+	return response, nil
 }
 
 // GetProduct retrieves a specific product by ID

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1704,8 +1704,9 @@ func TestGetRemoteCIs_Success(t *testing.T) {
 	result, err := client.GetRemoteCIs(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Len(t, result.RemoteCIs, 2)
-	assert.Equal(t, "rci-1", result.RemoteCIs[0].ID)
+	assert.Len(t, result, 1)
+	assert.Len(t, result[0].RemoteCIs, 2)
+	assert.Equal(t, "rci-1", result[0].RemoteCIs[0].ID)
 }
 
 func TestGetRemoteCIs_Error(t *testing.T) {
@@ -1719,7 +1720,7 @@ func TestGetRemoteCIs_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	result, err := client.GetRemoteCIs(context.Background())
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "HTTP")
 }
 
@@ -2243,9 +2244,10 @@ func TestGetProducts_Success(t *testing.T) {
 	result, err := client.GetProducts(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Len(t, result.Products, 2)
-	assert.Equal(t, "prod-1", result.Products[0].ID)
-	assert.Equal(t, "RHEL", result.Products[0].Name)
+	assert.Len(t, result, 1)
+	assert.Len(t, result[0].Products, 2)
+	assert.Equal(t, "prod-1", result[0].Products[0].ID)
+	assert.Equal(t, "RHEL", result[0].Products[0].Name)
 }
 
 func TestGetProducts_Error(t *testing.T) {
@@ -2259,7 +2261,7 @@ func TestGetProducts_Error(t *testing.T) {
 	client := newTestClient(server.URL)
 	result, err := client.GetProducts(context.Background())
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "HTTP")
 }
 


### PR DESCRIPTION
## Summary

- GetRemoteCIs and GetProducts were making single API calls without pagination, silently truncating results beyond the default page size
- Refactored both to use the existing paginate() helper, matching the pattern used by GetTeams, GetUsers, GetTopics, GetComponents, and GetComponentTypes
- Updated callers in cmd/, examples/, and all related tests to handle the new []XxxResponse return type
- JSON output now uses a consistent envelope with total count

Fixes #176