### PR TITLE
docs: fix missing context.Context and wrong flag names in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ go-dci topics
 package main
 
 import (
+    "context"
     "fmt"
     "log"
     "os"
@@ -40,13 +41,13 @@ func main() {
         os.Getenv("GO_DCI_SECRETKEY"),
     )
 
-    identity, err := client.GetIdentity()
+    identity, err := client.GetIdentity(context.Background())
     if err != nil {
         log.Fatalf("Authentication failed: %v", err)
     }
     fmt.Printf("Authenticated as: %s\n", identity.Identity.Name)
 
-    topics, err := client.GetTopics()
+    topics, err := client.GetTopics(context.Background())
     if err != nil {
         log.Fatal(err)
     }
@@ -105,22 +106,22 @@ go-dci create-component --name "My Component" --type ocp --topic-id <topic-id> -
 go-dci job --id <job-id>
 
 # Create a job
-go-dci create-job --topic-id <topic-id> --remoteci-id <remoteci-id>
+go-dci create-job --topic-id <topic-id> --components <component-id1>,<component-id2>
 
 # Update job state
-go-dci update-job-state --job-id <job-id> --state success --comment "All tests passed"
+go-dci update-job-state --job-id <job-id> --status success --comment "All tests passed"
 
 # Upload a file to a job
-go-dci upload-file --job-id <job-id> --file results.xml --mime-type application/xml
+go-dci upload-file --job-id <job-id> --file results.xml --mime application/xml
 ```
 
 ### File Operations
 ```bash
 # List files for a job
-go-dci job-files --job-id <job-id>
+go-dci job-files --id <job-id>
 
 # Download a specific file
-go-dci file --id <file-id> --output downloaded-file.xml
+go-dci file --id <file-id> --output-path downloaded-file.xml
 
 # Delete a file
 go-dci delete-file --id <file-id>

--- a/docs/library-guide.md
+++ b/docs/library-guide.md
@@ -14,6 +14,7 @@ go get github.com/sebrandon1/go-dci
 package main
 
 import (
+    "context"
     "os"
     "time"
 
@@ -59,7 +60,7 @@ DCI uses AWS Signature Version 4 for authentication. The library handles this au
 ### Verify Authentication
 
 ```go
-identity, err := client.GetIdentity()
+identity, err := client.GetIdentity(context.Background())
 if err != nil {
     log.Fatalf("Authentication failed: %v", err)
 }
@@ -72,114 +73,114 @@ fmt.Printf("Authenticated as: %s\n", identity.Identity.Name)
 
 ```go
 // Get current identity
-identity, err := client.GetIdentity()
+identity, err := client.GetIdentity(context.Background())
 ```
 
 ### Topic Operations
 
 ```go
 // List all topics
-topics, err := client.GetTopics()
+topics, err := client.GetTopics(context.Background())
 
 // Get specific topic
-topic, err := client.GetTopic(topicID)
+topic, err := client.GetTopic(context.Background(), topicID)
 
 // Create topic (admin)
-topic, err := client.CreateTopic(name, productID, componentTypes)
+topic, err := client.CreateTopic(context.Background(), name, productID, componentTypes)
 
 // Update topic
-topic, err := client.UpdateTopic(topicID, lib.UpdateTopicRequest{Name: "new-name"})
+topic, err := client.UpdateTopic(context.Background(), topicID, lib.UpdateTopicRequest{Name: "new-name"})
 
 // Delete topic (admin)
-err := client.DeleteTopic(topicID)
+err := client.DeleteTopic(context.Background(), topicID)
 
 // Get topic components
-components, err := client.GetTopicComponents(topicID)
+components, err := client.GetTopicComponents(context.Background(), topicID)
 ```
 
 ### Component Type Operations
 
 ```go
 // List all component types
-types, err := client.GetComponentTypes()
+types, err := client.GetComponentTypes(context.Background())
 
 // Get specific type
-compType, err := client.GetComponentType(typeID)
+compType, err := client.GetComponentType(context.Background(), typeID)
 
 // Create type (admin)
-compType, err := client.CreateComponentType(name)
+compType, err := client.CreateComponentType(context.Background(), name)
 
 // Update type
-compType, err := client.UpdateComponentType(typeID, lib.UpdateComponentTypeRequest{Name: "new"})
+compType, err := client.UpdateComponentType(context.Background(), typeID, lib.UpdateComponentTypeRequest{Name: "new"})
 
 // Delete type (admin)
-err := client.DeleteComponentType(typeID)
+err := client.DeleteComponentType(context.Background(), typeID)
 ```
 
 ### Component Operations
 
 ```go
 // List all components
-components, err := client.GetComponents()
+components, err := client.GetComponents(context.Background())
 
 // Get components by topic
-components, err := client.GetComponentsByTopicID(topicID)
+components, err := client.GetComponentsByTopicID(context.Background(), topicID)
 
 // Get specific component
-component, err := client.GetComponent(componentID)
+component, err := client.GetComponent(context.Background(), componentID)
 
 // Create component
-component, err := client.CreateComponent(name, componentType, topicID, version)
+component, err := client.CreateComponent(context.Background(), name, componentType, topicID, version)
 
 // Update component
-component, err := client.UpdateComponent(componentID, lib.UpdateComponentRequest{
+component, err := client.UpdateComponent(context.Background(), componentID, lib.UpdateComponentRequest{
     Name:    "updated-name",
     Version: "1.2.3",
 })
 
 // Delete component
-err := client.DeleteComponent(componentID)
+err := client.DeleteComponent(context.Background(), componentID)
 ```
 
 ### Job Operations
 
 ```go
 // List jobs (with day filter)
-jobs, err := client.GetJobs(30) // Last 30 days
+jobs, err := client.GetJobs(context.Background(), 30) // Last 30 days
 
 // List jobs by date range
-jobs, err := client.GetJobsByDate(startTime, endTime)
+jobs, err := client.GetJobsByDate(context.Background(), startTime, endTime)
 
 // Get specific job
-job, err := client.GetJob(jobID)
+job, err := client.GetJob(context.Background(), jobID)
 
 // Create job with components
-job, err := client.CreateJob(topicID, componentIDs, comment)
+job, err := client.CreateJob(context.Background(), topicID, componentIDs, comment)
 
 // Schedule job (auto-select components)
-job, err := client.ScheduleJob(topicID)
+job, err := client.ScheduleJob(context.Background(), topicID)
 
 // Update job
-job, err := client.UpdateJob(jobID, lib.UpdateJobRequest{Comment: "updated"})
+job, err := client.UpdateJob(context.Background(), jobID, lib.UpdateJobRequest{Comment: "updated"})
 
 // Delete job
-err := client.DeleteJob(jobID)
+err := client.DeleteJob(context.Background(), jobID)
 
 // Get job files
-files, err := client.GetJobFiles(jobID)
+files, err := client.GetJobFiles(context.Background(), jobID)
 ```
 
 ### Job State Operations
 
 ```go
 // Update job state
-state, err := client.UpdateJobState(jobID, lib.JobStateRunning, "Starting tests")
+state, err := client.UpdateJobState(context.Background(), jobID, lib.JobStateRunning, "Starting tests")
 
 // Mark job as successful
-state, err = client.UpdateJobState(jobID, lib.JobStateSuccess, "Tests passed")
+state, err = client.UpdateJobState(context.Background(), jobID, lib.JobStateSuccess, "Tests passed")
 
 // Get job states history
-states, err := client.GetJobStates(jobID)
+states, err := client.GetJobStates(context.Background(), jobID)
 ```
 
 ### Job States
@@ -199,89 +200,89 @@ lib.JobStateKilled    // "killed"
 
 ```go
 // Upload file from path
-upload, err := client.UploadFile(jobID, filePath, mimeType)
+upload, err := client.UploadFile(context.Background(), jobID, filePath, mimeType)
 
 // Upload file content
-upload, err := client.UploadFileContent(jobID, fileName, mimeType, content)
+upload, err := client.UploadFileContent(context.Background(), jobID, fileName, mimeType, content)
 
 // Get file (download)
-data, contentType, err := client.GetFile(fileID)
+data, contentType, err := client.GetFile(context.Background(), fileID)
 
 // Delete file
-err := client.DeleteFile(fileID)
+err := client.DeleteFile(context.Background(), fileID)
 ```
 
 ### RemoteCI Operations
 
 ```go
 // List RemoteCIs
-remotecis, err := client.GetRemoteCIs()
+remotecis, err := client.GetRemoteCIs(context.Background())
 
 // Get specific RemoteCI
-remoteci, err := client.GetRemoteCI(remoteciID)
+remoteci, err := client.GetRemoteCI(context.Background(), remoteciID)
 
 // Create RemoteCI (admin)
-remoteci, err := client.CreateRemoteCI(name, teamID)
+remoteci, err := client.CreateRemoteCI(context.Background(), name, teamID)
 
 // Update RemoteCI
-remoteci, err := client.UpdateRemoteCI(remoteciID, lib.UpdateRemoteCIRequest{Name: "new"})
+remoteci, err := client.UpdateRemoteCI(context.Background(), remoteciID, lib.UpdateRemoteCIRequest{Name: "new"})
 
 // Delete RemoteCI (admin)
-err := client.DeleteRemoteCI(remoteciID)
+err := client.DeleteRemoteCI(context.Background(), remoteciID)
 ```
 
 ### Team Operations
 
 ```go
 // List teams
-teams, err := client.GetTeams()
+teams, err := client.GetTeams(context.Background())
 
 // Get specific team
-team, err := client.GetTeam(teamID)
+team, err := client.GetTeam(context.Background(), teamID)
 
 // Create team (admin)
-team, err := client.CreateTeam(name)
+team, err := client.CreateTeam(context.Background(), name)
 
 // Update team
-team, err := client.UpdateTeam(teamID, lib.UpdateTeamRequest{Name: "new"})
+team, err := client.UpdateTeam(context.Background(), teamID, lib.UpdateTeamRequest{Name: "new"})
 
 // Delete team (admin)
-err := client.DeleteTeam(teamID)
+err := client.DeleteTeam(context.Background(), teamID)
 ```
 
 ### User Operations
 
 ```go
 // List users
-users, err := client.GetUsers()
+users, err := client.GetUsers(context.Background())
 
 // Get specific user
-user, err := client.GetUser(userID)
+user, err := client.GetUser(context.Background(), userID)
 
 // Create user (admin)
-user, err := client.CreateUser(name, email, fullname, teamID, password)
+user, err := client.CreateUser(context.Background(), name, email, fullname, teamID, password)
 
 // Update user
-user, err := client.UpdateUser(userID, lib.UpdateUserRequest{Name: "new"})
+user, err := client.UpdateUser(context.Background(), userID, lib.UpdateUserRequest{Name: "new"})
 
 // Delete user (admin)
-err := client.DeleteUser(userID)
+err := client.DeleteUser(context.Background(), userID)
 ```
 
 ### Product Operations
 
 ```go
 // List products
-products, err := client.GetProducts()
+products, err := client.GetProducts(context.Background())
 
 // Get specific product
-product, err := client.GetProduct(productID)
+product, err := client.GetProduct(context.Background(), productID)
 ```
 
 ## Error Handling
 
 ```go
-result, err := client.GetTopic(topicID)
+result, err := client.GetTopic(context.Background(), topicID)
 if err != nil {
     errStr := err.Error()
 


### PR DESCRIPTION
## Summary

- Added missing context.Background() argument to all library code examples in README.md and docs/library-guide.md
- Fixed 5 incorrect CLI flag names in README.md:
  - `--remoteci-id` -> `--components` (create-job)
  - `--state` -> `--status` (update-job-state)
  - `--mime-type` -> `--mime` (upload-file)
  - `--job-id` -> `--id` (job-files)
  - `--output` -> `--output-path` (file download)
- Added "context" to import block in library-guide.md

Fixes #174