### PR TITLE
fix: mask access key in config view output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,6 +33,16 @@ func formatConfigValue(label, value, fallback string) string {
 	return fmt.Sprintf("  %-12s %s\n", label+":", fallback)
 }
 
+func maskCredential(value string) string {
+	if value == "" {
+		return ""
+	}
+	if len(value) <= 4 {
+		return "****"
+	}
+	return "****" + value[len(value)-4:]
+}
+
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Set or get configuration values",
@@ -92,14 +102,10 @@ var viewCmd = &cobra.Command{
 		fmt.Println("Configuration:")
 
 		accessKey := GetConfigValue(configKeyAccessKey)
-		fmt.Print(formatConfigValue("Access Key", accessKey, "(not set)"))
+		fmt.Print(formatConfigValue("Access Key", maskCredential(accessKey), "(not set)"))
 
 		secretKey := GetConfigValue(configKeySecretKey)
-		maskedValue := ""
-		if secretKey != "" {
-			maskedValue = "***"
-		}
-		fmt.Print(formatConfigValue("Secret Key", maskedValue, "(not set)"))
+		fmt.Print(formatConfigValue("Secret Key", maskCredential(secretKey), "(not set)"))
 
 		configFile := viper.ConfigFileUsed()
 		fmt.Print(formatConfigValue("Config File", configFile, ".go-dci-config.yaml (default)"))

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -73,3 +73,11 @@ func TestUpdateConfigValue(t *testing.T) {
 	assert.Equal(t, "updatevalue", viper.GetString("updatekey"))
 }
 
+func TestMaskCredential(t *testing.T) {
+	assert.Equal(t, "", maskCredential(""))
+	assert.Equal(t, "****", maskCredential("abc"))
+	assert.Equal(t, "****", maskCredential("abcd"))
+	assert.Equal(t, "****fghi", maskCredential("abcdefghi"))
+	assert.Equal(t, "****cdef", maskCredential("abcdef"))
+}
+


### PR DESCRIPTION
## Summary

- Added maskCredential() helper that shows only the last 4 characters of credential values
- Applied to both access key and secret key in config view output
- Previously the access key was displayed in full while the secret key was masked

Fixes #173