### PR TITLE
fix: store config in ~/.config/go-dci/ with 0600 permissions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,9 +17,19 @@ func GetConfigValue(key string) string {
 	return viper.GetString(key)
 }
 
+func writeConfigSecure() error {
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+	if path := viper.ConfigFileUsed(); path != "" {
+		return os.Chmod(path, 0600)
+	}
+	return nil
+}
+
 func UpdateConfigValue(key, value string) error {
 	viper.Set(key, value)
-	if err := viper.WriteConfig(); err != nil {
+	if err := writeConfigSecure(); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 	return nil
@@ -85,8 +96,7 @@ var unsetCmd = &cobra.Command{
 		}
 
 		viper.Set(key, nil)
-		err := viper.WriteConfig()
-		if err != nil {
+		if err := writeConfigSecure(); err != nil {
 			return fmt.Errorf("writing config: %v", err)
 		}
 		fmt.Printf("Unset key '%s' from configuration\n", key)
@@ -108,7 +118,7 @@ var viewCmd = &cobra.Command{
 		fmt.Print(formatConfigValue("Secret Key", maskCredential(secretKey), "(not set)"))
 
 		configFile := viper.ConfigFileUsed()
-		fmt.Print(formatConfigValue("Config File", configFile, ".go-dci-config.yaml (default)"))
+		fmt.Print(formatConfigValue("Config File", configFile, "(not set)"))
 
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -118,21 +119,39 @@ func init() {
 }
 
 func initConfig() {
-	configFile = ".go-dci-config.yaml"
 	viper.SetConfigType("yaml")
-	viper.SetConfigFile(configFile)
-
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("GO_DCI")
 
-	// If the config file is not found, create it
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = "."
+	}
+	dciConfigDir := filepath.Join(configDir, "go-dci")
+	configFile = filepath.Join(dciConfigDir, "config.yaml")
+
+	legacyFile := ".go-dci-config.yaml"
+	_, legacyErr := os.Stat(legacyFile)
+	_, newErr := os.Stat(configFile)
+
+	if legacyErr == nil && newErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: using legacy config %s\n", legacyFile)
+		fmt.Fprintf(os.Stderr, "  Migrate to: %s\n", configFile)
+		configFile = legacyFile
+	}
+
+	viper.SetConfigFile(configFile)
+
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
-		if err := viper.WriteConfig(); err != nil {
-			fmt.Printf("Warning: could not create config file: %v\n", err)
+		if err := os.MkdirAll(filepath.Dir(configFile), 0700); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not create config dir: %v\n", err)
+		}
+		if err := os.WriteFile(configFile, []byte("{}\n"), 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not create config file: %v\n", err)
 		}
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Println("Error reading config file: ", err)
+		fmt.Fprintln(os.Stderr, "Error reading config file:", err)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,5 +35,6 @@ func TestInitConfig(t *testing.T) {
 	assert.NotPanics(t, func() {
 		initConfig()
 	})
-	assert.Equal(t, ".go-dci-config.yaml", configFile)
+	assert.Contains(t, configFile, "go-dci")
+	assert.True(t, strings.HasSuffix(configFile, "config.yaml") || strings.HasSuffix(configFile, ".go-dci-config.yaml"))
 }


### PR DESCRIPTION
## Summary

- Config file now defaults to the OS config directory (~/Library/Application Support/go-dci/config.yaml on macOS, ~/.config/go-dci/config.yaml on Linux) instead of the current working directory
- Config directory created with 0700 and config file with 0600 permissions to protect API credentials
- Added writeConfigSecure() helper that enforces 0600 on every write operation
- Legacy fallback: if .go-dci-config.yaml exists in CWD and the new path does not, the old file is used with a stderr migration warning

Fixes #169