### PR TITLE
fix: use %w for error wrapping in cmd/ to enable errors.Is/As

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -43,7 +43,7 @@ var getComponentCmd = &cobra.Command{
 
 		response, err := client.GetComponent(cmd.Context(), getComponentIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get component: %v", err)
+			return fmt.Errorf("failed to get component: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -76,7 +76,7 @@ var createComponentCmd = &cobra.Command{
 
 		response, err := client.CreateComponent(cmd.Context(), createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
 		if err != nil {
-			return fmt.Errorf("failed to create component: %v", err)
+			return fmt.Errorf("failed to create component: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -132,7 +132,7 @@ var updateComponentCmd = &cobra.Command{
 
 		response, err := client.UpdateComponent(cmd.Context(), updateComponentIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update component: %v", err)
+			return fmt.Errorf("failed to update component: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -180,7 +180,7 @@ var deleteComponentCmd = &cobra.Command{
 
 		err = client.DeleteComponent(cmd.Context(), deleteComponentIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete component: %v", err)
+			return fmt.Errorf("failed to delete component: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -216,7 +216,7 @@ func printComponentStdout(response *lib.ComponentResponse) {
 func printComponentJSON(response *lib.ComponentResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -37,7 +37,7 @@ var getComponentTypeCmd = &cobra.Command{
 
 		response, err := client.GetComponentType(cmd.Context(), getComponentTypeIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get component type: %v", err)
+			return fmt.Errorf("failed to get component type: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -70,7 +70,7 @@ var createComponentTypeCmd = &cobra.Command{
 
 		response, err := client.CreateComponentType(cmd.Context(), createComponentTypeName)
 		if err != nil {
-			return fmt.Errorf("failed to create component type: %v", err)
+			return fmt.Errorf("failed to create component type: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -116,7 +116,7 @@ var updateComponentTypeCmd = &cobra.Command{
 
 		response, err := client.UpdateComponentType(cmd.Context(), updateComponentTypeIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update component type: %v", err)
+			return fmt.Errorf("failed to update component type: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -165,7 +165,7 @@ var deleteComponentTypeCmd = &cobra.Command{
 
 		err = client.DeleteComponentType(cmd.Context(), deleteComponentTypeIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete component type: %v", err)
+			return fmt.Errorf("failed to delete component type: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -192,7 +192,7 @@ func printComponentTypeStdout(response *lib.ComponentTypeResponse) {
 func printComponentTypeJSON(response *lib.ComponentTypeResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -68,14 +68,14 @@ var setCmd = &cobra.Command{
 
 		if accesskey != "" {
 			if err := UpdateConfigValue(configKeyAccessKey, accesskey); err != nil {
-				return fmt.Errorf("setting accesskey: %v", err)
+				return fmt.Errorf("setting accesskey: %w", err)
 			}
 			printStatus("Access key updated successfully")
 		}
 
 		if secretkey != "" {
 			if err := UpdateConfigValue(configKeySecretKey, secretkey); err != nil {
-				return fmt.Errorf("setting secretkey: %v", err)
+				return fmt.Errorf("setting secretkey: %w", err)
 			}
 			printStatus("Secret key updated successfully")
 		}
@@ -97,7 +97,7 @@ var unsetCmd = &cobra.Command{
 
 		viper.Set(key, nil)
 		if err := writeConfigSecure(); err != nil {
-			return fmt.Errorf("writing config: %v", err)
+			return fmt.Errorf("writing config: %w", err)
 		}
 		fmt.Printf("Unset key '%s' from configuration\n", key)
 

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -35,12 +35,12 @@ var getFileCmd = &cobra.Command{
 
 		content, contentType, err := client.GetFile(cmd.Context(), getFileIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get file: %v", err)
+			return fmt.Errorf("failed to get file: %w", err)
 		}
 
 		if getFileOutputPath != "" {
 			if err := os.WriteFile(getFileOutputPath, content, 0644); err != nil {
-				return fmt.Errorf("failed to write file: %v", err)
+				return fmt.Errorf("failed to write file: %w", err)
 			}
 			fmt.Printf("File saved to: %s\n", getFileOutputPath)
 		} else if outputFormat == OutputFormatJSON {
@@ -97,7 +97,7 @@ var deleteFileCmd = &cobra.Command{
 
 		err = client.DeleteFile(cmd.Context(), deleteFileIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete file: %v", err)
+			return fmt.Errorf("failed to delete file: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -50,7 +50,7 @@ var getTopicsCmd = &cobra.Command{
 
 		topicsResponses, err := client.GetTopicsByName(cmd.Context(), nameFilter)
 		if err != nil {
-			return fmt.Errorf("failed to get topics: %v", err)
+			return fmt.Errorf("failed to get topics: %w", err)
 		}
 
 		totalTopics := 0
@@ -88,7 +88,7 @@ var getComponentTypesCmd = &cobra.Command{
 
 		componentTypesResponses, err := client.GetComponentTypesByName(cmd.Context(), nameFilter)
 		if err != nil {
-			return fmt.Errorf("failed to get component types: %v", err)
+			return fmt.Errorf("failed to get component types: %w", err)
 		}
 
 		totalComponentTypes := 0
@@ -120,7 +120,7 @@ var getIdentityCmd = &cobra.Command{
 
 		identity, err := client.GetIdentity(cmd.Context())
 		if err != nil {
-			return fmt.Errorf("authentication failed: %v", err)
+			return fmt.Errorf("authentication failed: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -153,7 +153,7 @@ var getOcpCountCmd = &cobra.Command{
 
 		jobsResponses, err := client.GetJobs(cmd.Context(), daysBackLimit)
 		if err != nil {
-			return fmt.Errorf("getting jobs: %v", err)
+			return fmt.Errorf("getting jobs: %w", err)
 		}
 
 		ocpVersionCount := countOcpVersions(jobsResponses)
@@ -198,7 +198,7 @@ var getComponentsCmd = &cobra.Command{
 
 		componentsResponses, err := client.GetComponentsFiltered(cmd.Context(), topicID, typeFilter, nameFilter)
 		if err != nil {
-			return fmt.Errorf("failed to get components: %v", err)
+			return fmt.Errorf("failed to get components: %w", err)
 		}
 
 		totalComponents := 0
@@ -262,7 +262,7 @@ var getJobsCmd = &cobra.Command{
 
 			jobsResponses, err = client.GetJobsByDate(cmd.Context(), parsedStart, parsedEnd)
 			if err != nil {
-				return fmt.Errorf("failed to get jobs: %v", err)
+				return fmt.Errorf("failed to get jobs: %w", err)
 			}
 		} else if startDate != "" || endDate != "" {
 			return fmt.Errorf("both --start-date and --end-date must be provided together")
@@ -276,7 +276,7 @@ var getJobsCmd = &cobra.Command{
 
 			jobsResponses, err = client.GetJobs(cmd.Context(), daysBackLimit)
 			if err != nil {
-				return fmt.Errorf("failed to get jobs: %v", err)
+				return fmt.Errorf("failed to get jobs: %w", err)
 			}
 		}
 
@@ -312,7 +312,7 @@ var getJobsCmd = &cobra.Command{
 		} else {
 			jsonOutputBytes, err := json.Marshal(jsonOutput)
 			if err != nil {
-				return fmt.Errorf("failed to marshal JSON output: %v", err)
+				return fmt.Errorf("failed to marshal JSON output: %w", err)
 			}
 			fmt.Println(string(jsonOutputBytes))
 		}
@@ -418,7 +418,7 @@ func printOcpVersionCountJSON(ocpVersionCount map[string]int) error {
 
 	jsonOutputBytes, err := json.Marshal(jsonOutput)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonOutputBytes))
 	return nil
@@ -464,7 +464,7 @@ func printComponentsJSON(componentsResponses []lib.ComponentsResponse) error {
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -496,7 +496,7 @@ func printIdentityStdout(identity *lib.IdentityResponse) {
 func printIdentityJSON(identity *lib.IdentityResponse) error {
 	jsonBytes, err := json.Marshal(identity)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -525,7 +525,7 @@ func printComponentTypesJSON(componentTypesResponses []lib.ComponentTypesRespons
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -577,7 +577,7 @@ func printTopicsJSON(topicsResponses []lib.TopicsResponse) error {
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -39,7 +39,7 @@ var getJobCmd = &cobra.Command{
 
 		response, err := client.GetJob(cmd.Context(), getJobIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get job: %v", err)
+			return fmt.Errorf("failed to get job: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -88,7 +88,7 @@ var updateJobCmd = &cobra.Command{
 
 		response, err := client.UpdateJob(cmd.Context(), updateJobIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update job: %v", err)
+			return fmt.Errorf("failed to update job: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -136,7 +136,7 @@ var deleteJobCmd = &cobra.Command{
 
 		err = client.DeleteJob(cmd.Context(), deleteJobIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete job: %v", err)
+			return fmt.Errorf("failed to delete job: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -175,7 +175,7 @@ var scheduleJobCmd = &cobra.Command{
 
 		response, err := client.ScheduleJob(cmd.Context(), scheduleJobTopicID)
 		if err != nil {
-			return fmt.Errorf("failed to schedule job: %v", err)
+			return fmt.Errorf("failed to schedule job: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -208,7 +208,7 @@ var getJobFilesCmd = &cobra.Command{
 
 		response, err := client.GetJobFiles(cmd.Context(), jobFilesIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get job files: %v", err)
+			return fmt.Errorf("failed to get job files: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -244,7 +244,7 @@ func printJobStdout(response *lib.JobResponse) {
 func printJobJSON(response *lib.JobResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -266,7 +266,7 @@ func printFilesStdout(response *lib.FilesResponse) {
 func printFilesJSON(response *lib.FilesResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -38,7 +38,7 @@ var getJobStatesCmd = &cobra.Command{
 
 		responses, err := client.GetJobStates(cmd.Context(), getJobStatesJobIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get job states: %v", err)
+			return fmt.Errorf("failed to get job states: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -84,7 +84,7 @@ func printJobStatesJSON(responses []lib.JobStatesResponse) error {
 
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -51,7 +51,7 @@ var createJobCmd = &cobra.Command{
 
 		response, err := client.CreateJob(cmd.Context(), createJobTopicID, componentIDs, createJobComment)
 		if err != nil {
-			return fmt.Errorf("failed to create job: %v", err)
+			return fmt.Errorf("failed to create job: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -101,7 +101,7 @@ var updateJobStateCmd = &cobra.Command{
 
 		response, err := client.UpdateJobState(cmd.Context(), updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
 		if err != nil {
-			return fmt.Errorf("failed to update job state: %v", err)
+			return fmt.Errorf("failed to update job state: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -139,7 +139,7 @@ var uploadFileCmd = &cobra.Command{
 
 		response, err := client.UploadFile(cmd.Context(), uploadFileJobID, uploadFilePath, uploadFileMimeType)
 		if err != nil {
-			return fmt.Errorf("failed to upload file: %v", err)
+			return fmt.Errorf("failed to upload file: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -165,7 +165,7 @@ func printCreateJobStdout(response *lib.CreateJobResponse) {
 func printCreateJobJSON(response *lib.CreateJobResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -186,7 +186,7 @@ func printJobStateStdout(response *lib.JobStateResponse) {
 func printJobStateJSON(response *lib.JobStateResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -206,7 +206,7 @@ func printUploadFileStdout(response *lib.UploadFileResponse) {
 func printUploadFileJSON(response *lib.UploadFileResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -28,7 +28,7 @@ var getProductsCmd = &cobra.Command{
 
 		responses, err := client.GetProducts(cmd.Context())
 		if err != nil {
-			return fmt.Errorf("failed to get products: %v", err)
+			return fmt.Errorf("failed to get products: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -60,7 +60,7 @@ var getProductCmd = &cobra.Command{
 
 		response, err := client.GetProduct(cmd.Context(), getProductIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get product: %v", err)
+			return fmt.Errorf("failed to get product: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -102,7 +102,7 @@ func printProductsJSON(responses []lib.ProductsResponse) error {
 		"total":    len(all),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -122,7 +122,7 @@ func printProductStdout(response *lib.ProductResponse) {
 func printProductJSON(response *lib.ProductResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -34,7 +34,7 @@ var getRemoteCIsCmd = &cobra.Command{
 
 		responses, err := client.GetRemoteCIs(cmd.Context())
 		if err != nil {
-			return fmt.Errorf("failed to get remote CIs: %v", err)
+			return fmt.Errorf("failed to get remote CIs: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -66,7 +66,7 @@ var getRemoteCICmd = &cobra.Command{
 
 		response, err := client.GetRemoteCI(cmd.Context(), getRemoteCIsCmd_IDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get remote CI: %v", err)
+			return fmt.Errorf("failed to get remote CI: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -99,7 +99,7 @@ var createRemoteCICmd = &cobra.Command{
 
 		response, err := client.CreateRemoteCI(cmd.Context(), createRemoteCINameFlag, createRemoteCITeamIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to create remote CI: %v", err)
+			return fmt.Errorf("failed to create remote CI: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -145,7 +145,7 @@ var updateRemoteCICmd = &cobra.Command{
 
 		response, err := client.UpdateRemoteCI(cmd.Context(), updateRemoteCIIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update remote CI: %v", err)
+			return fmt.Errorf("failed to update remote CI: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -194,7 +194,7 @@ var deleteRemoteCICmd = &cobra.Command{
 
 		err = client.DeleteRemoteCI(cmd.Context(), deleteRemoteCIIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete remote CI: %v", err)
+			return fmt.Errorf("failed to delete remote CI: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -238,7 +238,7 @@ func printRemoteCIsJSON(responses []lib.RemoteCIsResponse) error {
 		"total":     len(all),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -257,7 +257,7 @@ func printRemoteCIStdout(response *lib.RemoteCIResponse) {
 func printRemoteCIJSON(response *lib.RemoteCIResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -38,7 +38,7 @@ var getTeamsCmd = &cobra.Command{
 
 		response, err := client.GetTeamsFiltered(cmd.Context(), teamsNameFilter)
 		if err != nil {
-			return fmt.Errorf("failed to get teams: %v", err)
+			return fmt.Errorf("failed to get teams: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -70,7 +70,7 @@ var getTeamCmd = &cobra.Command{
 
 		response, err := client.GetTeam(cmd.Context(), getTeamIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get team: %v", err)
+			return fmt.Errorf("failed to get team: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -103,7 +103,7 @@ var createTeamCmd = &cobra.Command{
 
 		response, err := client.CreateTeam(cmd.Context(), createTeamNameFlag)
 		if err != nil {
-			return fmt.Errorf("failed to create team: %v", err)
+			return fmt.Errorf("failed to create team: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -149,7 +149,7 @@ var updateTeamCmd = &cobra.Command{
 
 		response, err := client.UpdateTeam(cmd.Context(), updateTeamIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update team: %v", err)
+			return fmt.Errorf("failed to update team: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -198,7 +198,7 @@ var deleteTeamCmd = &cobra.Command{
 
 		err = client.DeleteTeam(cmd.Context(), deleteTeamIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete team: %v", err)
+			return fmt.Errorf("failed to delete team: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -246,7 +246,7 @@ func printTeamsJSON(responses []lib.TeamsResponse) error {
 		"total": len(allTeams),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -266,7 +266,7 @@ func printTeamStdout(response *lib.TeamResponse) {
 func printTeamJSON(response *lib.TeamResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -40,7 +40,7 @@ var getTopicCmd = &cobra.Command{
 
 		response, err := client.GetTopic(cmd.Context(), getTopicIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get topic: %v", err)
+			return fmt.Errorf("failed to get topic: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -82,7 +82,7 @@ var createTopicCmd = &cobra.Command{
 
 		response, err := client.CreateTopic(cmd.Context(), createTopicName, createTopicProductID, componentTypes)
 		if err != nil {
-			return fmt.Errorf("failed to create topic: %v", err)
+			return fmt.Errorf("failed to create topic: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -125,7 +125,7 @@ var updateTopicCmd = &cobra.Command{
 
 		response, err := client.UpdateTopic(cmd.Context(), updateTopicIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update topic: %v", err)
+			return fmt.Errorf("failed to update topic: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -173,7 +173,7 @@ var deleteTopicCmd = &cobra.Command{
 
 		err = client.DeleteTopic(cmd.Context(), deleteTopicIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete topic: %v", err)
+			return fmt.Errorf("failed to delete topic: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -207,7 +207,7 @@ var getTopicComponentsCmd = &cobra.Command{
 
 		componentsResponses, err := client.GetTopicComponents(cmd.Context(), topicComponentsIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get topic components: %v", err)
+			return fmt.Errorf("failed to get topic components: %w", err)
 		}
 
 		totalComponents := 0
@@ -243,7 +243,7 @@ func printTopicStdout(response *lib.TopicResponse) {
 func printTopicJSON(response *lib.TopicResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -46,7 +46,7 @@ var getUsersCmd = &cobra.Command{
 
 		response, err := client.GetUsersFiltered(cmd.Context(), usersNameFilter)
 		if err != nil {
-			return fmt.Errorf("failed to get users: %v", err)
+			return fmt.Errorf("failed to get users: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -78,7 +78,7 @@ var getUserCmd = &cobra.Command{
 
 		response, err := client.GetUser(cmd.Context(), getUserIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to get user: %v", err)
+			return fmt.Errorf("failed to get user: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -134,7 +134,7 @@ var createUserCmd = &cobra.Command{
 			password,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to create user: %v", err)
+			return fmt.Errorf("failed to create user: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -186,7 +186,7 @@ var updateUserCmd = &cobra.Command{
 
 		response, err := client.UpdateUser(cmd.Context(), updateUserIDFlag, updates)
 		if err != nil {
-			return fmt.Errorf("failed to update user: %v", err)
+			return fmt.Errorf("failed to update user: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -235,7 +235,7 @@ var deleteUserCmd = &cobra.Command{
 
 		err = client.DeleteUser(cmd.Context(), deleteUserIDFlag)
 		if err != nil {
-			return fmt.Errorf("failed to delete user: %v", err)
+			return fmt.Errorf("failed to delete user: %w", err)
 		}
 
 		if outputFormat == OutputFormatJSON {
@@ -283,7 +283,7 @@ func printUsersJSON(responses []lib.UsersResponse) error {
 		"total": len(allUsers),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil
@@ -304,7 +304,7 @@ func printUserStdout(response *lib.UserResponse) {
 func printUserJSON(response *lib.UserResponse) error {
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	fmt.Println(string(jsonBytes))
 	return nil


### PR DESCRIPTION
## Summary

- Replaced 75 instances of `%v` with `%w` in `fmt.Errorf` calls across all cmd/ files
- Enables `errors.Is()` and `errors.As()` for callers that need programmatic error inspection
- No behavioral change — all errors are still printed the same way by Cobra

Fixes #192