### PR TITLE
fix: use Topic type in TopicsResponse instead of anonymous struct

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -394,22 +394,7 @@ func TestPrintTopicsStdout(t *testing.T) {
 	topicsResponses := []lib.TopicsResponse{
 		{
 			Meta: lib.Meta{Count: 1},
-			Topics: []struct {
-				ComponentTypes         []string `json:"component_types,omitempty"`
-				ComponentTypesOptional []any    `json:"component_types_optional,omitempty"`
-				CreatedAt              string   `json:"created_at,omitempty"`
-				Data                   struct{} `json:"data,omitempty"`
-				Etag                   string   `json:"etag,omitempty"`
-				ExportControl          bool     `json:"export_control,omitempty"`
-				ID                     string   `json:"id,omitempty"`
-				Name                   string   `json:"name,omitempty"`
-				NextTopic              any      `json:"next_topic,omitempty"`
-				NextTopicID            any      `json:"next_topic_id,omitempty"`
-				Product                lib.Product `json:"product,omitempty"`
-				ProductID              string   `json:"product_id,omitempty"`
-				State                  string   `json:"state,omitempty"`
-				UpdatedAt              string   `json:"updated_at,omitempty"`
-			}{
+			Topics: []lib.Topic{
 				{
 					ID:        "topic-123",
 					Name:      "OCP-4.14",
@@ -436,22 +421,7 @@ func TestPrintTopicsJSON(t *testing.T) {
 	topicsResponses := []lib.TopicsResponse{
 		{
 			Meta: lib.Meta{Count: 1},
-			Topics: []struct {
-				ComponentTypes         []string `json:"component_types,omitempty"`
-				ComponentTypesOptional []any    `json:"component_types_optional,omitempty"`
-				CreatedAt              string   `json:"created_at,omitempty"`
-				Data                   struct{} `json:"data,omitempty"`
-				Etag                   string   `json:"etag,omitempty"`
-				ExportControl          bool     `json:"export_control,omitempty"`
-				ID                     string   `json:"id,omitempty"`
-				Name                   string   `json:"name,omitempty"`
-				NextTopic              any      `json:"next_topic,omitempty"`
-				NextTopicID            any      `json:"next_topic_id,omitempty"`
-				Product                lib.Product `json:"product,omitempty"`
-				ProductID              string   `json:"product_id,omitempty"`
-				State                  string   `json:"state,omitempty"`
-				UpdatedAt              string   `json:"updated_at,omitempty"`
-			}{
+			Topics: []lib.Topic{
 				{
 					ID:            "topic-123",
 					Name:          "OCP-4.14",

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -712,23 +712,7 @@ func TestGetTopics_Success(t *testing.T) {
 
 		response := TopicsResponse{
 			Meta: Meta{Count: 1},
-			Topics: []struct {
-				ComponentTypes         []string `json:"component_types,omitempty"`
-				ComponentTypesOptional []any    `json:"component_types_optional,omitempty"`
-				CreatedAt              string   `json:"created_at,omitempty"`
-				Data                   struct {
-				} `json:"data,omitempty"`
-				Etag          string  `json:"etag,omitempty"`
-				ExportControl bool    `json:"export_control,omitempty"`
-				ID            string  `json:"id,omitempty"`
-				Name          string  `json:"name,omitempty"`
-				NextTopic     any     `json:"next_topic,omitempty"`
-				NextTopicID   any     `json:"next_topic_id,omitempty"`
-				Product       Product `json:"product,omitempty"`
-				ProductID     string  `json:"product_id,omitempty"`
-				State         string  `json:"state,omitempty"`
-				UpdatedAt     string  `json:"updated_at,omitempty"`
-			}{
+			Topics: []Topic{
 				{
 					ID:        "topic-1",
 					Name:      "OCP-4.14",
@@ -945,23 +929,7 @@ func TestFetchTopics_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := TopicsResponse{
 			Meta: Meta{Count: 1},
-			Topics: []struct {
-				ComponentTypes         []string `json:"component_types,omitempty"`
-				ComponentTypesOptional []any    `json:"component_types_optional,omitempty"`
-				CreatedAt              string   `json:"created_at,omitempty"`
-				Data                   struct {
-				} `json:"data,omitempty"`
-				Etag          string  `json:"etag,omitempty"`
-				ExportControl bool    `json:"export_control,omitempty"`
-				ID            string  `json:"id,omitempty"`
-				Name          string  `json:"name,omitempty"`
-				NextTopic     any     `json:"next_topic,omitempty"`
-				NextTopicID   any     `json:"next_topic_id,omitempty"`
-				Product       Product `json:"product,omitempty"`
-				ProductID     string  `json:"product_id,omitempty"`
-				State         string  `json:"state,omitempty"`
-				UpdatedAt     string  `json:"updated_at,omitempty"`
-			}{
+			Topics: []Topic{
 				{ID: "topic-1", Name: "test"},
 			},
 		}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -223,24 +223,8 @@ type JobsResponse struct {
 }
 
 type TopicsResponse struct {
-	Meta   Meta `json:"_meta,omitempty"`
-	Topics []struct {
-		ComponentTypes         []string `json:"component_types,omitempty"`
-		ComponentTypesOptional []any    `json:"component_types_optional,omitempty"`
-		CreatedAt              string   `json:"created_at,omitempty"`
-		Data                   struct {
-		} `json:"data,omitempty"`
-		Etag          string  `json:"etag,omitempty"`
-		ExportControl bool    `json:"export_control,omitempty"`
-		ID            string  `json:"id,omitempty"`
-		Name          string  `json:"name,omitempty"`
-		NextTopic     any     `json:"next_topic,omitempty"`
-		NextTopicID   any     `json:"next_topic_id,omitempty"`
-		Product       Product `json:"product,omitempty"`
-		ProductID     string  `json:"product_id,omitempty"`
-		State         string  `json:"state,omitempty"`
-		UpdatedAt     string  `json:"updated_at,omitempty"`
-	} `json:"topics,omitempty"`
+	Meta   Meta    `json:"_meta,omitempty"`
+	Topics []Topic `json:"topics,omitempty"`
 }
 
 type ComponentsResponse struct {
@@ -287,18 +271,20 @@ type ComponentType struct {
 
 // Topic represents a single topic in DCI
 type Topic struct {
-	ID                     string   `json:"id,omitempty"`
-	Name                   string   `json:"name,omitempty"`
-	ComponentTypes         []string `json:"component_types,omitempty"`
-	ComponentTypesOptional []string `json:"component_types_optional,omitempty"`
-	ProductID              string   `json:"product_id,omitempty"`
-	NextTopicID            string   `json:"next_topic_id,omitempty"`
-	ExportControl          bool     `json:"export_control,omitempty"`
-	State                  string   `json:"state,omitempty"`
-	Etag                   string   `json:"etag,omitempty"`
-	CreatedAt              string   `json:"created_at,omitempty"`
-	UpdatedAt              string   `json:"updated_at,omitempty"`
-	Product                Product  `json:"product,omitempty"`
+	ID                     string    `json:"id,omitempty"`
+	Name                   string    `json:"name,omitempty"`
+	ComponentTypes         []string  `json:"component_types,omitempty"`
+	ComponentTypesOptional []string  `json:"component_types_optional,omitempty"`
+	ProductID              string    `json:"product_id,omitempty"`
+	NextTopicID            string    `json:"next_topic_id,omitempty"`
+	NextTopic              any       `json:"next_topic,omitempty"`
+	ExportControl          bool      `json:"export_control,omitempty"`
+	State                  string    `json:"state,omitempty"`
+	Etag                   string    `json:"etag,omitempty"`
+	Data                   struct{}  `json:"data,omitempty"`
+	CreatedAt              string    `json:"created_at,omitempty"`
+	UpdatedAt              string    `json:"updated_at,omitempty"`
+	Product                Product   `json:"product,omitempty"`
 }
 
 // TopicResponse represents a single topic response from the API


### PR DESCRIPTION
## Summary

- Replaced the anonymous struct in TopicsResponse.Topics with the existing Topic type
- Added two missing fields to Topic (Data and NextTopic) that the anonymous struct had
- Removed 76 lines of duplicated struct definition across source and test files
- Changes are type-only with no behavioral impact

Fixes #194