### PR TITLE
refactor: consolidate --output flag to rootCmd PersistentFlags

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -231,7 +231,6 @@ func init() {
 	// get component flags
 	getComponentCmd.PersistentFlags().StringVar(&getComponentIDFlag, "id", "", "Component ID")
 	_ = getComponentCmd.MarkPersistentFlagRequired("id")
-	getComponentCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create component flags
 	createComponentCmd.PersistentFlags().StringVar(&createComponentName, "name", "", "Component name")
@@ -241,7 +240,6 @@ func init() {
 	createComponentCmd.PersistentFlags().StringVar(&createComponentTopicID, "topic-id", "", "Topic ID")
 	_ = createComponentCmd.MarkPersistentFlagRequired("topic-id")
 	createComponentCmd.PersistentFlags().StringVar(&createComponentVersion, "version", "", "Component version")
-	createComponentCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update component flags
 	updateComponentCmd.PersistentFlags().StringVar(&updateComponentIDFlag, "id", "", "Component ID to update")
@@ -250,10 +248,8 @@ func init() {
 	updateComponentCmd.PersistentFlags().StringVar(&updateComponentState, "state", "", "New component state")
 	updateComponentCmd.PersistentFlags().StringVar(&updateComponentVersion, "version", "", "New component version")
 	updateComponentCmd.PersistentFlags().StringVar(&updateComponentTags, "tags", "", "Comma-separated list of tags")
-	updateComponentCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete component flags
 	deleteComponentCmd.PersistentFlags().StringVar(&deleteComponentIDFlag, "id", "", "Component ID to delete")
 	_ = deleteComponentCmd.MarkPersistentFlagRequired("id")
-	deleteComponentCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -207,22 +207,18 @@ func init() {
 	// get component type flags
 	getComponentTypeCmd.PersistentFlags().StringVar(&getComponentTypeIDFlag, "id", "", "Component Type ID")
 	_ = getComponentTypeCmd.MarkPersistentFlagRequired("id")
-	getComponentTypeCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create component type flags
 	createComponentTypeCmd.PersistentFlags().StringVar(&createComponentTypeName, "name", "", "Component type name")
 	_ = createComponentTypeCmd.MarkPersistentFlagRequired("name")
-	createComponentTypeCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update component type flags
 	updateComponentTypeCmd.PersistentFlags().StringVar(&updateComponentTypeIDFlag, "id", "", "Component Type ID to update")
 	_ = updateComponentTypeCmd.MarkPersistentFlagRequired("id")
 	updateComponentTypeCmd.PersistentFlags().StringVar(&updateComponentTypeName, "name", "", "New component type name")
 	updateComponentTypeCmd.PersistentFlags().StringVar(&updateComponentTypeState, "state", "", "New component type state")
-	updateComponentTypeCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete component type flags
 	deleteComponentTypeCmd.PersistentFlags().StringVar(&deleteComponentTypeIDFlag, "id", "", "Component Type ID to delete")
 	_ = deleteComponentTypeCmd.MarkPersistentFlagRequired("id")
-	deleteComponentTypeCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -120,10 +120,8 @@ func init() {
 	getFileCmd.PersistentFlags().StringVar(&getFileIDFlag, "id", "", "File ID")
 	_ = getFileCmd.MarkPersistentFlagRequired("id")
 	getFileCmd.PersistentFlags().StringVar(&getFileOutputPath, "output-path", "", "Path to save the file content")
-	getFileCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete file flags
 	deleteFileCmd.PersistentFlags().StringVar(&deleteFileIDFlag, "id", "", "File ID to delete")
 	_ = deleteFileCmd.MarkPersistentFlagRequired("id")
-	deleteFileCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,7 +13,6 @@ import (
 )
 
 var ageInDays string
-var outputFormat string
 var topicID string
 var startDate string
 var endDate string
@@ -21,10 +20,8 @@ var nameFilter string
 var typeFilter string
 
 const (
-	dateFormat         = "2006-01-02T15:04:05.999999"
-	dateFormatDay      = "2006-01-02"
-	OutputFormatJSON   = "json"
-	OutputFormatStdout = "stdout"
+	dateFormat    = "2006-01-02T15:04:05.999999"
+	dateFormatDay = "2006-01-02"
 )
 
 var (
@@ -594,21 +591,15 @@ func init() {
 	getJobsCmd.PersistentFlags().StringVarP(&ageInDays, "age", "d", "", "Age in days")
 	getJobsCmd.PersistentFlags().StringVarP(&startDate, "start-date", "s", "", "Start date for job query (YYYY-MM-DD)")
 	getJobsCmd.PersistentFlags().StringVarP(&endDate, "end-date", "e", "", "End date for job query (YYYY-MM-DD)")
-	getJobsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	getOcpCountCmd.PersistentFlags().StringVarP(&ageInDays, "age", "d", "", "Age in days")
-	getOcpCountCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	getComponentsCmd.PersistentFlags().StringVarP(&topicID, "topic", "t", "", "Filter components by topic ID")
 	getComponentsCmd.PersistentFlags().StringVar(&typeFilter, "type", "", "Filter components by type")
 	getComponentsCmd.PersistentFlags().StringVarP(&nameFilter, "name", "n", "", "Filter components by name")
-	getComponentsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
-	getIdentityCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	getComponentTypesCmd.PersistentFlags().StringVarP(&nameFilter, "name", "n", "", "Filter component types by name")
-	getComponentTypesCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	getTopicsCmd.PersistentFlags().StringVarP(&nameFilter, "name", "n", "", "Filter topics by name")
-	getTopicsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -282,27 +282,22 @@ func init() {
 	// get job flags
 	getJobCmd.PersistentFlags().StringVar(&getJobIDFlag, "id", "", "Job ID")
 	_ = getJobCmd.MarkPersistentFlagRequired("id")
-	getJobCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update job flags
 	updateJobCmd.PersistentFlags().StringVar(&updateJobIDFlag, "id", "", "Job ID to update")
 	_ = updateJobCmd.MarkPersistentFlagRequired("id")
 	updateJobCmd.PersistentFlags().StringVar(&updateJobComment, "comment", "", "New comment for the job")
 	updateJobCmd.PersistentFlags().StringVar(&updateJobTags, "tags", "", "Comma-separated list of tags")
-	updateJobCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete job flags
 	deleteJobCmd.PersistentFlags().StringVar(&deleteJobIDFlag, "id", "", "Job ID to delete")
 	_ = deleteJobCmd.MarkPersistentFlagRequired("id")
-	deleteJobCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// schedule job flags
 	scheduleJobCmd.PersistentFlags().StringVar(&scheduleJobTopicID, "topic-id", "", "Topic ID for the job")
 	_ = scheduleJobCmd.MarkPersistentFlagRequired("topic-id")
-	scheduleJobCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get job files flags
 	getJobFilesCmd.PersistentFlags().StringVar(&jobFilesIDFlag, "id", "", "Job ID")
 	_ = getJobFilesCmd.MarkPersistentFlagRequired("id")
-	getJobFilesCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -95,5 +95,4 @@ func init() {
 
 	// get job states flags
 	getJobStatesCmd.PersistentFlags().StringVar(&getJobStatesJobIDFlag, "job-id", "", "Filter by Job ID (optional)")
-	getJobStatesCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -222,7 +222,6 @@ func init() {
 	_ = createJobCmd.MarkPersistentFlagRequired("topic-id")
 	createJobCmd.PersistentFlags().StringVar(&createJobComponents, "components", "", "Comma-separated list of component IDs")
 	createJobCmd.PersistentFlags().StringVar(&createJobComment, "comment", "", "Optional comment for the job")
-	createJobCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update-job-state flags
 	updateJobStateCmd.PersistentFlags().StringVar(&updateJobStateJobID, "job-id", "", "Job ID to update")
@@ -230,7 +229,6 @@ func init() {
 	updateJobStateCmd.PersistentFlags().StringVar(&updateJobStateStatus, "status", "", "New status (pre-run, running, success, failure, etc.)")
 	_ = updateJobStateCmd.MarkPersistentFlagRequired("status")
 	updateJobStateCmd.PersistentFlags().StringVar(&updateJobStateComment, "comment", "", "Optional comment for the state change")
-	updateJobStateCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// upload-file flags
 	uploadFileCmd.PersistentFlags().StringVar(&uploadFileJobID, "job-id", "", "Job ID to attach the file to")
@@ -238,6 +236,5 @@ func init() {
 	uploadFileCmd.PersistentFlags().StringVar(&uploadFilePath, "file", "", "Path to the file to upload")
 	_ = uploadFileCmd.MarkPersistentFlagRequired("file")
 	uploadFileCmd.PersistentFlags().StringVar(&uploadFileMimeType, "mime", "application/junit", "MIME type of the file (default: application/junit)")
-	uploadFileCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }
 

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -133,10 +133,8 @@ func init() {
 	rootCmd.AddCommand(getProductCmd)
 
 	// get products flags
-	getProductsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get product flags
 	getProductCmd.PersistentFlags().StringVar(&getProductIDFlag, "id", "", "Product ID")
 	_ = getProductCmd.MarkPersistentFlagRequired("id")
-	getProductCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -271,29 +271,24 @@ func init() {
 	rootCmd.AddCommand(deleteRemoteCICmd)
 
 	// get remote CIs flags
-	getRemoteCIsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get remote CI flags
 	getRemoteCICmd.PersistentFlags().StringVar(&getRemoteCIsCmd_IDFlag, "id", "", "Remote CI ID")
 	_ = getRemoteCICmd.MarkPersistentFlagRequired("id")
-	getRemoteCICmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create remote CI flags
 	createRemoteCICmd.PersistentFlags().StringVar(&createRemoteCINameFlag, "name", "", "Remote CI name")
 	_ = createRemoteCICmd.MarkPersistentFlagRequired("name")
 	createRemoteCICmd.PersistentFlags().StringVar(&createRemoteCITeamIDFlag, "team-id", "", "Team ID")
 	_ = createRemoteCICmd.MarkPersistentFlagRequired("team-id")
-	createRemoteCICmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update remote CI flags
 	updateRemoteCICmd.PersistentFlags().StringVar(&updateRemoteCIIDFlag, "id", "", "Remote CI ID to update")
 	_ = updateRemoteCICmd.MarkPersistentFlagRequired("id")
 	updateRemoteCICmd.PersistentFlags().StringVar(&updateRemoteCINameFlag, "name", "", "New remote CI name")
 	updateRemoteCICmd.PersistentFlags().StringVar(&updateRemoteCIStateFlag, "state", "", "New remote CI state")
-	updateRemoteCICmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete remote CI flags
 	deleteRemoteCICmd.PersistentFlags().StringVar(&deleteRemoteCIIDFlag, "id", "", "Remote CI ID to delete")
 	_ = deleteRemoteCICmd.MarkPersistentFlagRequired("id")
-	deleteRemoteCICmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,12 +21,18 @@ var rootCmd = &cobra.Command{
 	Version: Version,
 }
 
+const (
+	OutputFormatJSON   = "json"
+	OutputFormatStdout = "stdout"
+)
+
 var (
-	configFile  string
-	yesFlag     bool
-	quietFlag   bool
-	verboseFlag bool
-	dryRunFlag  bool
+	configFile   string
+	outputFormat string
+	yesFlag      bool
+	quietFlag    bool
+	verboseFlag  bool
+	dryRunFlag   bool
 )
 
 // printStatus prints a status message unless --quiet or JSON output is enabled.
@@ -116,6 +122,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress non-essential output")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Show verbose output (HTTP requests, timing)")
 	rootCmd.PersistentFlags().BoolVar(&dryRunFlag, "dry-run", false, "Show what would happen without executing")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }
 
 func initConfig() {

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -281,27 +281,22 @@ func init() {
 
 	// get teams flags
 	getTeamsCmd.PersistentFlags().StringVarP(&teamsNameFilter, "name", "n", "", "Filter teams by name")
-	getTeamsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get team flags
 	getTeamCmd.PersistentFlags().StringVar(&getTeamIDFlag, "id", "", "Team ID")
 	_ = getTeamCmd.MarkPersistentFlagRequired("id")
-	getTeamCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create team flags
 	createTeamCmd.PersistentFlags().StringVar(&createTeamNameFlag, "name", "", "Team name")
 	_ = createTeamCmd.MarkPersistentFlagRequired("name")
-	createTeamCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update team flags
 	updateTeamCmd.PersistentFlags().StringVar(&updateTeamIDFlag, "id", "", "Team ID to update")
 	_ = updateTeamCmd.MarkPersistentFlagRequired("id")
 	updateTeamCmd.PersistentFlags().StringVar(&updateTeamNameFlag, "name", "", "New team name")
 	updateTeamCmd.PersistentFlags().StringVar(&updateTeamStateFlag, "state", "", "New team state")
-	updateTeamCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete team flags
 	deleteTeamCmd.PersistentFlags().StringVar(&deleteTeamIDFlag, "id", "", "Team ID to delete")
 	_ = deleteTeamCmd.MarkPersistentFlagRequired("id")
-	deleteTeamCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -259,7 +259,6 @@ func init() {
 	// get topic flags
 	getTopicCmd.PersistentFlags().StringVar(&getTopicIDFlag, "id", "", "Topic ID")
 	_ = getTopicCmd.MarkPersistentFlagRequired("id")
-	getTopicCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create topic flags
 	createTopicCmd.PersistentFlags().StringVar(&createTopicName, "name", "", "Topic name")
@@ -267,21 +266,17 @@ func init() {
 	createTopicCmd.PersistentFlags().StringVar(&createTopicProductID, "product-id", "", "Product ID")
 	_ = createTopicCmd.MarkPersistentFlagRequired("product-id")
 	createTopicCmd.PersistentFlags().StringVar(&createTopicComponentTypes, "component-types", "", "Comma-separated list of component type names")
-	createTopicCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update topic flags
 	updateTopicCmd.PersistentFlags().StringVar(&updateTopicIDFlag, "id", "", "Topic ID to update")
 	_ = updateTopicCmd.MarkPersistentFlagRequired("id")
 	updateTopicCmd.PersistentFlags().StringVar(&updateTopicName, "name", "", "New topic name")
-	updateTopicCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete topic flags
 	deleteTopicCmd.PersistentFlags().StringVar(&deleteTopicIDFlag, "id", "", "Topic ID to delete")
 	_ = deleteTopicCmd.MarkPersistentFlagRequired("id")
-	deleteTopicCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get topic components flags
 	getTopicComponentsCmd.PersistentFlags().StringVar(&topicComponentsIDFlag, "id", "", "Topic ID")
 	_ = getTopicComponentsCmd.MarkPersistentFlagRequired("id")
-	getTopicComponentsCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -319,12 +319,10 @@ func init() {
 
 	// get users flags
 	getUsersCmd.PersistentFlags().StringVarP(&usersNameFilter, "name", "n", "", "Filter users by name")
-	getUsersCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// get user flags
 	getUserCmd.PersistentFlags().StringVar(&getUserIDFlag, "id", "", "User ID")
 	_ = getUserCmd.MarkPersistentFlagRequired("id")
-	getUserCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// create user flags
 	createUserCmd.PersistentFlags().StringVar(&createUserNameFlag, "name", "", "Username")
@@ -335,7 +333,6 @@ func init() {
 	createUserCmd.PersistentFlags().StringVar(&createUserTeamIDFlag, "team-id", "", "Team ID")
 	_ = createUserCmd.MarkPersistentFlagRequired("team-id")
 	createUserCmd.PersistentFlags().StringVar(&createUserPasswordFlag, "password", "", "User password (prompts interactively if omitted)")
-	createUserCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// update user flags
 	updateUserCmd.PersistentFlags().StringVar(&updateUserIDFlag, "id", "", "User ID to update")
@@ -344,10 +341,8 @@ func init() {
 	updateUserCmd.PersistentFlags().StringVar(&updateUserEmailFlag, "email", "", "New email")
 	updateUserCmd.PersistentFlags().StringVar(&updateUserFullnameFlag, "fullname", "", "New full name")
 	updateUserCmd.PersistentFlags().StringVar(&updateUserStateFlag, "state", "", "New user state")
-	updateUserCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 
 	// delete user flags
 	deleteUserCmd.PersistentFlags().StringVar(&deleteUserIDFlag, "id", "", "User ID to delete")
 	_ = deleteUserCmd.MarkPersistentFlagRequired("id")
-	deleteUserCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
 }


### PR DESCRIPTION
## Summary

- Moved outputFormat variable and OutputFormatJSON/OutputFormatStdout constants from cmd/get.go to cmd/root.go
- Registered --output flag once on rootCmd.PersistentFlags() instead of 47 individual registrations across 12 files
- Removed 47 duplicate flag registration lines with no behavioral change

Fixes #177