### PR TITLE
fix: redact API secrets and pull secrets from JSON output

### DIFF
--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -242,6 +242,7 @@ func printJobStdout(response *lib.JobResponse) {
 }
 
 func printJobJSON(response *lib.JobResponse) error {
+	lib.RedactJob(&response.Job)
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -163,6 +163,7 @@ func printCreateJobStdout(response *lib.CreateJobResponse) {
 }
 
 func printCreateJobJSON(response *lib.CreateJobResponse) error {
+	lib.RedactJob(&response.Job)
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -231,6 +231,9 @@ func printRemoteCIsStdout(responses []lib.RemoteCIsResponse) {
 func printRemoteCIsJSON(responses []lib.RemoteCIsResponse) error {
 	var all []lib.RemoteCI
 	for _, resp := range responses {
+		for i := range resp.RemoteCIs {
+			lib.RedactRemoteCI(&resp.RemoteCIs[i])
+		}
 		all = append(all, resp.RemoteCIs...)
 	}
 	jsonBytes, err := json.Marshal(map[string]any{
@@ -255,6 +258,7 @@ func printRemoteCIStdout(response *lib.RemoteCIResponse) {
 }
 
 func printRemoteCIJSON(response *lib.RemoteCIResponse) error {
+	lib.RedactRemoteCI(&response.RemoteCI)
 	jsonBytes, err := json.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)

--- a/lib/redact.go
+++ b/lib/redact.go
@@ -1,0 +1,16 @@
+package lib
+
+const redactedPlaceholder = "**REDACTED**"
+
+func RedactJob(job *Job) {
+	job.Remoteci.APISecret = redactedPlaceholder
+	job.Topic.Data.PullSecret.Auths.CloudOpenshiftCom.Auth = redactedPlaceholder
+	job.Topic.Data.PullSecret.Auths.QuayIo.Auth = redactedPlaceholder
+	job.Topic.Data.PullSecret.Auths.RegistryCiOpenshiftOrg.Auth = redactedPlaceholder
+	job.Topic.Data.PullSecret.Auths.RegistryConnectRedhatCom.Auth = redactedPlaceholder
+	job.Topic.Data.PullSecret.Auths.RegistryRedhatIo.Auth = redactedPlaceholder
+}
+
+func RedactRemoteCI(rci *RemoteCI) {
+	rci.APISecret = redactedPlaceholder
+}

--- a/lib/redact_test.go
+++ b/lib/redact_test.go
@@ -1,0 +1,46 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactJob(t *testing.T) {
+	job := &Job{
+		ID:   "job-123",
+		Name: "test-job",
+	}
+	job.Remoteci.APISecret = "secret-api-key"
+	job.Topic.Data.PullSecret.Auths.CloudOpenshiftCom.Auth = "cloud-auth"
+	job.Topic.Data.PullSecret.Auths.QuayIo.Auth = "quay-auth"
+	job.Topic.Data.PullSecret.Auths.RegistryCiOpenshiftOrg.Auth = "registry-ci-auth"
+	job.Topic.Data.PullSecret.Auths.RegistryConnectRedhatCom.Auth = "registry-connect-auth"
+	job.Topic.Data.PullSecret.Auths.RegistryRedhatIo.Auth = "registry-redhat-auth"
+
+	RedactJob(job)
+
+	assert.Equal(t, redactedPlaceholder, job.Remoteci.APISecret)
+	assert.Equal(t, redactedPlaceholder, job.Topic.Data.PullSecret.Auths.CloudOpenshiftCom.Auth)
+	assert.Equal(t, redactedPlaceholder, job.Topic.Data.PullSecret.Auths.QuayIo.Auth)
+	assert.Equal(t, redactedPlaceholder, job.Topic.Data.PullSecret.Auths.RegistryCiOpenshiftOrg.Auth)
+	assert.Equal(t, redactedPlaceholder, job.Topic.Data.PullSecret.Auths.RegistryConnectRedhatCom.Auth)
+	assert.Equal(t, redactedPlaceholder, job.Topic.Data.PullSecret.Auths.RegistryRedhatIo.Auth)
+
+	assert.Equal(t, "job-123", job.ID)
+	assert.Equal(t, "test-job", job.Name)
+}
+
+func TestRedactRemoteCI(t *testing.T) {
+	rci := &RemoteCI{
+		ID:        "rci-123",
+		Name:      "test-rci",
+		APISecret: "secret-key",
+	}
+
+	RedactRemoteCI(rci)
+
+	assert.Equal(t, redactedPlaceholder, rci.APISecret)
+	assert.Equal(t, "rci-123", rci.ID)
+	assert.Equal(t, "test-rci", rci.Name)
+}


### PR DESCRIPTION
## Summary

- Added RedactJob() and RedactRemoteCI() functions in lib/redact.go that replace secret fields with **REDACTED**
- Applied redaction before json.Marshal in printJobJSON, printCreateJobJSON, printRemoteCIJSON, and printRemoteCIsJSON
- Redacted fields: Job.Remoteci.APISecret, 5 registry auth tokens in Job.Topic.Data.PullSecret, RemoteCI.APISecret
- Using a redaction function (not json:"-" tags) preserves the ability to deserialize these fields from API responses

Fixes #170