### PR TITLE
refactor: centralize client creation in PersistentPreRunE

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -32,16 +32,10 @@ var getComponentCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting component with ID: %s\n", getComponentIDFlag)
 
-		response, err := client.GetComponent(cmd.Context(), getComponentIDFlag)
+		response, err := dciClient.GetComponent(cmd.Context(), getComponentIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get component: %w", err)
 		}
@@ -60,12 +54,6 @@ var createComponentCmd = &cobra.Command{
 	Use:   "create-component",
 	Short: "Create a new component in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would create component: name=%s, type=%s, topic-id=%s, version=%s\n", createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
@@ -74,7 +62,7 @@ var createComponentCmd = &cobra.Command{
 
 		printStatus("Creating component: %s\n", createComponentName)
 
-		response, err := client.CreateComponent(cmd.Context(), createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
+		response, err := dciClient.CreateComponent(cmd.Context(), createComponentName, createComponentType, createComponentTopicID, createComponentVersion)
 		if err != nil {
 			return fmt.Errorf("failed to create component: %w", err)
 		}
@@ -98,12 +86,6 @@ var updateComponentCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateComponentRequest{}
 		if updateComponentName != "" {
@@ -130,7 +112,7 @@ var updateComponentCmd = &cobra.Command{
 
 		printStatus("Updating component: %s\n", updateComponentIDFlag)
 
-		response, err := client.UpdateComponent(cmd.Context(), updateComponentIDFlag, updates)
+		response, err := dciClient.UpdateComponent(cmd.Context(), updateComponentIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update component: %w", err)
 		}
@@ -154,11 +136,6 @@ var deleteComponentCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete component: id=%s\n", deleteComponentIDFlag)
 			return nil
@@ -174,11 +151,9 @@ var deleteComponentCmd = &cobra.Command{
 			return nil
 		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting component: %s\n", deleteComponentIDFlag)
 
-		err = client.DeleteComponent(cmd.Context(), deleteComponentIDFlag)
+		err = dciClient.DeleteComponent(cmd.Context(), deleteComponentIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete component: %w", err)
 		}

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -26,16 +26,10 @@ var getComponentTypeCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting component type with ID: %s\n", getComponentTypeIDFlag)
 
-		response, err := client.GetComponentType(cmd.Context(), getComponentTypeIDFlag)
+		response, err := dciClient.GetComponentType(cmd.Context(), getComponentTypeIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get component type: %w", err)
 		}
@@ -54,12 +48,6 @@ var createComponentTypeCmd = &cobra.Command{
 	Use:   "create-componenttype",
 	Short: "Create a new component type in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would create component type: name=%s\n", createComponentTypeName)
@@ -68,7 +56,7 @@ var createComponentTypeCmd = &cobra.Command{
 
 		printStatus("Creating component type: %s\n", createComponentTypeName)
 
-		response, err := client.CreateComponentType(cmd.Context(), createComponentTypeName)
+		response, err := dciClient.CreateComponentType(cmd.Context(), createComponentTypeName)
 		if err != nil {
 			return fmt.Errorf("failed to create component type: %w", err)
 		}
@@ -92,12 +80,6 @@ var updateComponentTypeCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateComponentTypeRequest{}
 		if updateComponentTypeName != "" {
@@ -114,7 +96,7 @@ var updateComponentTypeCmd = &cobra.Command{
 
 		printStatus("Updating component type: %s\n", updateComponentTypeIDFlag)
 
-		response, err := client.UpdateComponentType(cmd.Context(), updateComponentTypeIDFlag, updates)
+		response, err := dciClient.UpdateComponentType(cmd.Context(), updateComponentTypeIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update component type: %w", err)
 		}
@@ -138,11 +120,6 @@ var deleteComponentTypeCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete component type: id=%s\n", deleteComponentTypeIDFlag)
 			return nil
@@ -158,12 +135,9 @@ var deleteComponentTypeCmd = &cobra.Command{
 			return nil
 		}
 
-
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting component type: %s\n", deleteComponentTypeIDFlag)
 
-		err = client.DeleteComponentType(cmd.Context(), deleteComponentTypeIDFlag)
+		err = dciClient.DeleteComponentType(cmd.Context(), deleteComponentTypeIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete component type: %w", err)
 		}

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -24,16 +23,10 @@ var getFileCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Downloading file with ID: %s\n", getFileIDFlag)
 
-		content, contentType, err := client.GetFile(cmd.Context(), getFileIDFlag)
+		content, contentType, err := dciClient.GetFile(cmd.Context(), getFileIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get file: %w", err)
 		}
@@ -70,11 +63,6 @@ var deleteFileCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete file: id=%s\n", deleteFileIDFlag)
 			return nil
@@ -90,12 +78,9 @@ var deleteFileCmd = &cobra.Command{
 			return nil
 		}
 
-
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting file: %s\n", deleteFileIDFlag)
 
-		err = client.DeleteFile(cmd.Context(), deleteFileIDFlag)
+		err = dciClient.DeleteFile(cmd.Context(), deleteFileIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete file: %w", err)
 		}

--- a/cmd/filesCmd_test.go
+++ b/cmd/filesCmd_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/sebrandon1/go-dci/lib"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,24 +40,24 @@ func TestDeleteFileCmd_MissingID(t *testing.T) {
 
 func TestGetFileCmd_MissingCredentials(t *testing.T) {
 	viper.Reset()
+	defer viper.Reset()
 
-	getFileIDFlag = "550e8400-e29b-41d4-a716-446655440000"
-	defer func() { getFileIDFlag = "" }()
-
-	cmd := &cobra.Command{}
-	err := getFileCmd.RunE(cmd, []string{})
+	// Credential validation is centralized in PersistentPreRunE.
+	// Execute through cobra so PersistentPreRunE runs.
+	rootCmd.SetArgs([]string{"file", "--id", "550e8400-e29b-41d4-a716-446655440000"})
+	err := rootCmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "DCI credentials not configured")
 }
 
 func TestDeleteFileCmd_MissingCredentials(t *testing.T) {
 	viper.Reset()
+	defer viper.Reset()
 
-	deleteFileIDFlag = "550e8400-e29b-41d4-a716-446655440000"
-	defer func() { deleteFileIDFlag = "" }()
-
-	cmd := &cobra.Command{}
-	err := deleteFileCmd.RunE(cmd, []string{})
+	// Credential validation is centralized in PersistentPreRunE.
+	// Execute through cobra so PersistentPreRunE runs.
+	rootCmd.SetArgs([]string{"delete-file", "--id", "550e8400-e29b-41d4-a716-446655440000"})
+	err := rootCmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "DCI credentials not configured")
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -32,12 +32,6 @@ var getTopicsCmd = &cobra.Command{
 	Use:   "topics",
 	Short: "Get all topics from DCI, optionally filtered by name",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if nameFilter != "" {
 			printStatus("Getting topics matching name: %s\n", nameFilter)
@@ -45,7 +39,7 @@ var getTopicsCmd = &cobra.Command{
 			printStatus("Getting all topics from DCI")
 		}
 
-		topicsResponses, err := client.GetTopicsByName(cmd.Context(), nameFilter)
+		topicsResponses, err := dciClient.GetTopicsByName(cmd.Context(), nameFilter)
 		if err != nil {
 			return fmt.Errorf("failed to get topics: %w", err)
 		}
@@ -70,12 +64,6 @@ var getComponentTypesCmd = &cobra.Command{
 	Use:   "componenttypes",
 	Short: "Get all component types from DCI, optionally filtered by name",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if nameFilter != "" {
 			printStatus("Getting component types matching name: %s\n", nameFilter)
@@ -83,7 +71,7 @@ var getComponentTypesCmd = &cobra.Command{
 			printStatus("Getting all component types from DCI")
 		}
 
-		componentTypesResponses, err := client.GetComponentTypesByName(cmd.Context(), nameFilter)
+		componentTypesResponses, err := dciClient.GetComponentTypesByName(cmd.Context(), nameFilter)
 		if err != nil {
 			return fmt.Errorf("failed to get component types: %w", err)
 		}
@@ -108,14 +96,8 @@ var getIdentityCmd = &cobra.Command{
 	Use:   "identity",
 	Short: "Verify authentication and display current identity information",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
-		identity, err := client.GetIdentity(cmd.Context())
+		identity, err := dciClient.GetIdentity(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("authentication failed: %w", err)
 		}
@@ -134,11 +116,6 @@ var getOcpCountCmd = &cobra.Command{
 	Use:   "ocpcount",
 	Short: "Get the count of jobs for each OCP version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		printStatus("Getting all jobs from DCI that are %s days old\n", ageInDays)
 
 		daysBackLimit, err := strconv.Atoi(ageInDays)
@@ -146,9 +123,7 @@ var getOcpCountCmd = &cobra.Command{
 			return fmt.Errorf("invalid age value '%s': %v", ageInDays, err)
 		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
-		jobsResponses, err := client.GetJobs(cmd.Context(), daysBackLimit)
+		jobsResponses, err := dciClient.GetJobs(cmd.Context(), daysBackLimit)
 		if err != nil {
 			return fmt.Errorf("getting jobs: %w", err)
 		}
@@ -169,12 +144,6 @@ var getComponentsCmd = &cobra.Command{
 	Use:   "components",
 	Short: "Get all components, optionally filtered by topic, type, or name",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		var statusMsg string
 		if topicID != "" || typeFilter != "" || nameFilter != "" {
@@ -193,7 +162,7 @@ var getComponentsCmd = &cobra.Command{
 			printStatus("Getting all components from DCI")
 		}
 
-		componentsResponses, err := client.GetComponentsFiltered(cmd.Context(), topicID, typeFilter, nameFilter)
+		componentsResponses, err := dciClient.GetComponentsFiltered(cmd.Context(), topicID, typeFilter, nameFilter)
 		if err != nil {
 			return fmt.Errorf("failed to get components: %w", err)
 		}
@@ -218,11 +187,6 @@ var getJobsCmd = &cobra.Command{
 	Use:   "jobs",
 	Short: "Get all jobs with a specific age in days or date range",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if ageInDays != "" && (startDate != "" || endDate != "") {
 			return fmt.Errorf("--age and --start-date/--end-date are mutually exclusive")
 		}
@@ -236,8 +200,6 @@ var getJobsCmd = &cobra.Command{
 		certsuiteJobsCtr := 0
 		totalJobsCtr := 0
 		startRun := time.Now()
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		var jobsResponses []lib.JobsResponse
 
@@ -257,7 +219,7 @@ var getJobsCmd = &cobra.Command{
 
 			printStatus("Getting all jobs from DCI between %s and %s\n", startDate, endDate)
 
-			jobsResponses, err = client.GetJobsByDate(cmd.Context(), parsedStart, parsedEnd)
+			jobsResponses, err = dciClient.GetJobsByDate(cmd.Context(), parsedStart, parsedEnd)
 			if err != nil {
 				return fmt.Errorf("failed to get jobs: %w", err)
 			}
@@ -271,7 +233,7 @@ var getJobsCmd = &cobra.Command{
 				return fmt.Errorf("invalid age value '%s': %v", ageInDays, err)
 			}
 
-			jobsResponses, err = client.GetJobs(cmd.Context(), daysBackLimit)
+			jobsResponses, err = dciClient.GetJobs(cmd.Context(), daysBackLimit)
 			if err != nil {
 				return fmt.Errorf("failed to get jobs: %w", err)
 			}
@@ -336,23 +298,6 @@ func findOcpVersionFromComponents(components []lib.Components) string {
 	}
 
 	return ""
-}
-
-func getCredentials() (string, string, error) {
-	accessKey := GetConfigValue("accesskey")
-	secretKey := GetConfigValue("secretkey")
-
-	if accessKey == "" || secretKey == "" {
-		return "", "", fmt.Errorf(`DCI credentials not configured
-
-To configure credentials, use one of:
-  1. Config file:  go-dci config set --accesskey <key> --secretkey <secret>
-  2. Environment:  export GO_DCI_ACCESSKEY=<key> GO_DCI_SECRETKEY=<secret>
-
-Get credentials from: https://www.distributed-ci.io/`)
-	}
-
-	return accessKey, secretKey, nil
 }
 
 // getOCPVersions reads the OCP_VERSIONS_TO_TRACK environment variable

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -28,16 +28,10 @@ var getJobCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting job with ID: %s\n", getJobIDFlag)
 
-		response, err := client.GetJob(cmd.Context(), getJobIDFlag)
+		response, err := dciClient.GetJob(cmd.Context(), getJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job: %w", err)
 		}
@@ -60,12 +54,6 @@ var updateJobCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateJobRequest{}
 		if updateJobComment != "" {
@@ -86,7 +74,7 @@ var updateJobCmd = &cobra.Command{
 
 		printStatus("Updating job: %s\n", updateJobIDFlag)
 
-		response, err := client.UpdateJob(cmd.Context(), updateJobIDFlag, updates)
+		response, err := dciClient.UpdateJob(cmd.Context(), updateJobIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update job: %w", err)
 		}
@@ -110,11 +98,6 @@ var deleteJobCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete job: id=%s\n", deleteJobIDFlag)
 			return nil
@@ -130,11 +113,9 @@ var deleteJobCmd = &cobra.Command{
 			return nil
 		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting job: %s\n", deleteJobIDFlag)
 
-		err = client.DeleteJob(cmd.Context(), deleteJobIDFlag)
+		err = dciClient.DeleteJob(cmd.Context(), deleteJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete job: %w", err)
 		}
@@ -159,12 +140,6 @@ var scheduleJobCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would schedule job: topic-id=%s\n", scheduleJobTopicID)
@@ -173,7 +148,7 @@ var scheduleJobCmd = &cobra.Command{
 
 		printStatus("Scheduling job for topic: %s\n", scheduleJobTopicID)
 
-		response, err := client.ScheduleJob(cmd.Context(), scheduleJobTopicID)
+		response, err := dciClient.ScheduleJob(cmd.Context(), scheduleJobTopicID)
 		if err != nil {
 			return fmt.Errorf("failed to schedule job: %w", err)
 		}
@@ -197,16 +172,10 @@ var getJobFilesCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting files for job ID: %s\n", jobFilesIDFlag)
 
-		response, err := client.GetJobFiles(cmd.Context(), jobFilesIDFlag)
+		response, err := dciClient.GetJobFiles(cmd.Context(), jobFilesIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job files: %w", err)
 		}

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -23,12 +23,6 @@ var getJobStatesCmd = &cobra.Command{
 			}
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if getJobStatesJobIDFlag != "" {
 			printStatus("Getting job states for job ID: %s", getJobStatesJobIDFlag)
@@ -36,7 +30,7 @@ var getJobStatesCmd = &cobra.Command{
 			printStatus("Getting all job states...")
 		}
 
-		responses, err := client.GetJobStates(cmd.Context(), getJobStatesJobIDFlag)
+		responses, err := dciClient.GetJobStates(cmd.Context(), getJobStatesJobIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get job states: %w", err)
 		}

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -26,12 +26,6 @@ var createJobCmd = &cobra.Command{
 	Use:   "create-job",
 	Short: "Create a new job in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		// Parse component IDs if provided
 		var componentIDs []string
@@ -49,7 +43,7 @@ var createJobCmd = &cobra.Command{
 
 		printStatus("Creating job for topic ID: %s\n", createJobTopicID)
 
-		response, err := client.CreateJob(cmd.Context(), createJobTopicID, componentIDs, createJobComment)
+		response, err := dciClient.CreateJob(cmd.Context(), createJobTopicID, componentIDs, createJobComment)
 		if err != nil {
 			return fmt.Errorf("failed to create job: %w", err)
 		}
@@ -72,11 +66,6 @@ var updateJobStateCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		// Validate status
 		validStatuses := []string{"new", "pre-run", "running", "post-run", "success", "failure", "killed", "error"}
 		isValid := false
@@ -90,8 +79,6 @@ var updateJobStateCmd = &cobra.Command{
 			return fmt.Errorf("invalid status '%s'. Valid values: %s", updateJobStateStatus, strings.Join(validStatuses, ", "))
 		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would update job state: job-id=%s, status=%s, comment=%q\n", updateJobStateJobID, updateJobStateStatus, updateJobStateComment)
 			return nil
@@ -99,7 +86,7 @@ var updateJobStateCmd = &cobra.Command{
 
 		printStatus("Updating job %s to status: %s\n", updateJobStateJobID, updateJobStateStatus)
 
-		response, err := client.UpdateJobState(cmd.Context(), updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
+		response, err := dciClient.UpdateJobState(cmd.Context(), updateJobStateJobID, lib.JobState(updateJobStateStatus), updateJobStateComment)
 		if err != nil {
 			return fmt.Errorf("failed to update job state: %w", err)
 		}
@@ -118,17 +105,10 @@ var uploadFileCmd = &cobra.Command{
 	Use:   "upload-file",
 	Short: "Upload a file (e.g., test results) to a job in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		// Default mime type for test results
 		if uploadFileMimeType == "" {
 			uploadFileMimeType = "application/junit"
 		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would upload file: job-id=%s, file=%s, mime=%s\n", uploadFileJobID, uploadFilePath, uploadFileMimeType)
@@ -137,7 +117,7 @@ var uploadFileCmd = &cobra.Command{
 
 		printStatus("Uploading file %s to job %s\n", uploadFilePath, uploadFileJobID)
 
-		response, err := client.UploadFile(cmd.Context(), uploadFileJobID, uploadFilePath, uploadFileMimeType)
+		response, err := dciClient.UploadFile(cmd.Context(), uploadFileJobID, uploadFilePath, uploadFileMimeType)
 		if err != nil {
 			return fmt.Errorf("failed to upload file: %w", err)
 		}

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -17,16 +17,10 @@ var getProductsCmd = &cobra.Command{
 	Use:   "products",
 	Short: "Get all products from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting products...")
 
-		responses, err := client.GetProducts(cmd.Context())
+		responses, err := dciClient.GetProducts(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get products: %w", err)
 		}
@@ -49,16 +43,10 @@ var getProductCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting product with ID: %s\n", getProductIDFlag)
 
-		response, err := client.GetProduct(cmd.Context(), getProductIDFlag)
+		response, err := dciClient.GetProduct(cmd.Context(), getProductIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get product: %w", err)
 		}

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -23,16 +23,10 @@ var getRemoteCIsCmd = &cobra.Command{
 	Use:   "remotecis",
 	Short: "Get all remote CIs from DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting remote CIs...")
 
-		responses, err := client.GetRemoteCIs(cmd.Context())
+		responses, err := dciClient.GetRemoteCIs(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to get remote CIs: %w", err)
 		}
@@ -55,16 +49,10 @@ var getRemoteCICmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting remote CI with ID: %s\n", getRemoteCIsCmd_IDFlag)
 
-		response, err := client.GetRemoteCI(cmd.Context(), getRemoteCIsCmd_IDFlag)
+		response, err := dciClient.GetRemoteCI(cmd.Context(), getRemoteCIsCmd_IDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get remote CI: %w", err)
 		}
@@ -83,12 +71,6 @@ var createRemoteCICmd = &cobra.Command{
 	Use:   "create-remoteci",
 	Short: "Create a new remote CI in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would create remote CI: name=%s, team-id=%s\n", createRemoteCINameFlag, createRemoteCITeamIDFlag)
@@ -97,7 +79,7 @@ var createRemoteCICmd = &cobra.Command{
 
 		printStatus("Creating remote CI: %s\n", createRemoteCINameFlag)
 
-		response, err := client.CreateRemoteCI(cmd.Context(), createRemoteCINameFlag, createRemoteCITeamIDFlag)
+		response, err := dciClient.CreateRemoteCI(cmd.Context(), createRemoteCINameFlag, createRemoteCITeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to create remote CI: %w", err)
 		}
@@ -121,12 +103,6 @@ var updateRemoteCICmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateRemoteCIRequest{}
 		if updateRemoteCINameFlag != "" {
@@ -143,7 +119,7 @@ var updateRemoteCICmd = &cobra.Command{
 
 		printStatus("Updating remote CI: %s\n", updateRemoteCIIDFlag)
 
-		response, err := client.UpdateRemoteCI(cmd.Context(), updateRemoteCIIDFlag, updates)
+		response, err := dciClient.UpdateRemoteCI(cmd.Context(), updateRemoteCIIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update remote CI: %w", err)
 		}
@@ -167,11 +143,6 @@ var deleteRemoteCICmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete remote CI: id=%s\n", deleteRemoteCIIDFlag)
 			return nil
@@ -187,12 +158,9 @@ var deleteRemoteCICmd = &cobra.Command{
 			return nil
 		}
 
-
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting remote CI: %s\n", deleteRemoteCIIDFlag)
 
-		err = client.DeleteRemoteCI(cmd.Context(), deleteRemoteCIIDFlag)
+		err = dciClient.DeleteRemoteCI(cmd.Context(), deleteRemoteCIIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete remote CI: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sebrandon1/go-dci/lib"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -33,6 +34,7 @@ var (
 	quietFlag    bool
 	verboseFlag  bool
 	dryRunFlag   bool
+	dciClient    *lib.Client
 )
 
 // printStatus prints a status message unless --quiet or JSON output is enabled.
@@ -107,6 +109,23 @@ func readPassword(prompt string) (string, error) {
 	return string(password), nil
 }
 
+func getCredentials() (string, string, error) {
+	accessKey := GetConfigValue("accesskey")
+	secretKey := GetConfigValue("secretkey")
+
+	if accessKey == "" || secretKey == "" {
+		return "", "", fmt.Errorf(`DCI credentials not configured
+
+To configure credentials, use one of:
+  1. Config file:  go-dci config set --accesskey <key> --secretkey <secret>
+  2. Environment:  export GO_DCI_ACCESSKEY=<key> GO_DCI_SECRETKEY=<secret>
+
+Get credentials from: https://www.distributed-ci.io/`)
+	}
+
+	return accessKey, secretKey, nil
+}
+
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -123,6 +142,20 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Show verbose output (HTTP requests, timing)")
 	rootCmd.PersistentFlags().BoolVar(&dryRunFlag, "dry-run", false, "Show what would happen without executing")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatStdout, "Output format (json) - default is stdout")
+
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		for c := cmd; c != nil; c = c.Parent() {
+			if c.Name() == "config" {
+				return nil
+			}
+		}
+		accessKey, secretKey, err := getCredentials()
+		if err != nil {
+			return err
+		}
+		dciClient = lib.NewClient(accessKey, secretKey)
+		return nil
+	}
 }
 
 func initConfig() {

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -23,12 +23,6 @@ var getTeamsCmd = &cobra.Command{
 	Use:   "teams",
 	Short: "Get all teams from DCI, optionally filtered by name",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if teamsNameFilter != "" {
 			printStatus("Getting teams matching name: %s\n", teamsNameFilter)
@@ -36,7 +30,7 @@ var getTeamsCmd = &cobra.Command{
 			printStatus("Getting teams...")
 		}
 
-		response, err := client.GetTeamsFiltered(cmd.Context(), teamsNameFilter)
+		response, err := dciClient.GetTeamsFiltered(cmd.Context(), teamsNameFilter)
 		if err != nil {
 			return fmt.Errorf("failed to get teams: %w", err)
 		}
@@ -59,16 +53,10 @@ var getTeamCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting team with ID: %s\n", getTeamIDFlag)
 
-		response, err := client.GetTeam(cmd.Context(), getTeamIDFlag)
+		response, err := dciClient.GetTeam(cmd.Context(), getTeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get team: %w", err)
 		}
@@ -87,12 +75,6 @@ var createTeamCmd = &cobra.Command{
 	Use:   "create-team",
 	Short: "Create a new team in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would create team: name=%s\n", createTeamNameFlag)
@@ -101,7 +83,7 @@ var createTeamCmd = &cobra.Command{
 
 		printStatus("Creating team: %s\n", createTeamNameFlag)
 
-		response, err := client.CreateTeam(cmd.Context(), createTeamNameFlag)
+		response, err := dciClient.CreateTeam(cmd.Context(), createTeamNameFlag)
 		if err != nil {
 			return fmt.Errorf("failed to create team: %w", err)
 		}
@@ -125,12 +107,6 @@ var updateTeamCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateTeamRequest{}
 		if updateTeamNameFlag != "" {
@@ -147,7 +123,7 @@ var updateTeamCmd = &cobra.Command{
 
 		printStatus("Updating team: %s\n", updateTeamIDFlag)
 
-		response, err := client.UpdateTeam(cmd.Context(), updateTeamIDFlag, updates)
+		response, err := dciClient.UpdateTeam(cmd.Context(), updateTeamIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update team: %w", err)
 		}
@@ -171,11 +147,6 @@ var deleteTeamCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete team: id=%s\n", deleteTeamIDFlag)
 			return nil
@@ -191,12 +162,9 @@ var deleteTeamCmd = &cobra.Command{
 			return nil
 		}
 
-
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting team: %s\n", deleteTeamIDFlag)
 
-		err = client.DeleteTeam(cmd.Context(), deleteTeamIDFlag)
+		err = dciClient.DeleteTeam(cmd.Context(), deleteTeamIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete team: %w", err)
 		}

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -29,16 +29,10 @@ var getTopicCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting topic with ID: %s\n", getTopicIDFlag)
 
-		response, err := client.GetTopic(cmd.Context(), getTopicIDFlag)
+		response, err := dciClient.GetTopic(cmd.Context(), getTopicIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get topic: %w", err)
 		}
@@ -57,12 +51,6 @@ var createTopicCmd = &cobra.Command{
 	Use:   "create-topic",
 	Short: "Create a new topic in DCI",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		// Parse component types if provided
 		var componentTypes []string
@@ -80,7 +68,7 @@ var createTopicCmd = &cobra.Command{
 
 		printStatus("Creating topic: %s\n", createTopicName)
 
-		response, err := client.CreateTopic(cmd.Context(), createTopicName, createTopicProductID, componentTypes)
+		response, err := dciClient.CreateTopic(cmd.Context(), createTopicName, createTopicProductID, componentTypes)
 		if err != nil {
 			return fmt.Errorf("failed to create topic: %w", err)
 		}
@@ -104,12 +92,6 @@ var updateTopicCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateTopicRequest{}
 		if updateTopicName != "" {
@@ -123,7 +105,7 @@ var updateTopicCmd = &cobra.Command{
 
 		printStatus("Updating topic: %s\n", updateTopicIDFlag)
 
-		response, err := client.UpdateTopic(cmd.Context(), updateTopicIDFlag, updates)
+		response, err := dciClient.UpdateTopic(cmd.Context(), updateTopicIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update topic: %w", err)
 		}
@@ -147,11 +129,6 @@ var deleteTopicCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete topic: id=%s\n", deleteTopicIDFlag)
 			return nil
@@ -167,11 +144,9 @@ var deleteTopicCmd = &cobra.Command{
 			return nil
 		}
 
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting topic: %s\n", deleteTopicIDFlag)
 
-		err = client.DeleteTopic(cmd.Context(), deleteTopicIDFlag)
+		err = dciClient.DeleteTopic(cmd.Context(), deleteTopicIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete topic: %w", err)
 		}
@@ -196,16 +171,10 @@ var getTopicComponentsCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting components for topic ID: %s\n", topicComponentsIDFlag)
 
-		componentsResponses, err := client.GetTopicComponents(cmd.Context(), topicComponentsIDFlag)
+		componentsResponses, err := dciClient.GetTopicComponents(cmd.Context(), topicComponentsIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get topic components: %w", err)
 		}

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -31,12 +31,6 @@ var getUsersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Get all users from DCI, optionally filtered by name",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if usersNameFilter != "" {
 			printStatus("Getting users matching name: %s\n", usersNameFilter)
@@ -44,7 +38,7 @@ var getUsersCmd = &cobra.Command{
 			printStatus("Getting users...")
 		}
 
-		response, err := client.GetUsersFiltered(cmd.Context(), usersNameFilter)
+		response, err := dciClient.GetUsersFiltered(cmd.Context(), usersNameFilter)
 		if err != nil {
 			return fmt.Errorf("failed to get users: %w", err)
 		}
@@ -67,16 +61,10 @@ var getUserCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		printStatus("Getting user with ID: %s\n", getUserIDFlag)
 
-		response, err := client.GetUser(cmd.Context(), getUserIDFlag)
+		response, err := dciClient.GetUser(cmd.Context(), getUserIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to get user: %w", err)
 		}
@@ -111,12 +99,6 @@ var createUserCmd = &cobra.Command{
 			}
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would create user: name=%s, email=%s, fullname=%s, team-id=%s\n", createUserNameFlag, createUserEmailFlag, createUserFullnameFlag, createUserTeamIDFlag)
@@ -125,7 +107,7 @@ var createUserCmd = &cobra.Command{
 
 		printStatus("Creating user: %s\n", createUserNameFlag)
 
-		response, err := client.CreateUser(
+		response, err := dciClient.CreateUser(
 			cmd.Context(),
 			createUserNameFlag,
 			createUserEmailFlag,
@@ -156,12 +138,6 @@ var updateUserCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
-		client := lib.NewClient(accessKey, secretKey)
 
 		updates := lib.UpdateUserRequest{}
 		if updateUserNameFlag != "" {
@@ -184,7 +160,7 @@ var updateUserCmd = &cobra.Command{
 
 		printStatus("Updating user: %s\n", updateUserIDFlag)
 
-		response, err := client.UpdateUser(cmd.Context(), updateUserIDFlag, updates)
+		response, err := dciClient.UpdateUser(cmd.Context(), updateUserIDFlag, updates)
 		if err != nil {
 			return fmt.Errorf("failed to update user: %w", err)
 		}
@@ -208,11 +184,6 @@ var deleteUserCmd = &cobra.Command{
 			return err
 		}
 
-		accessKey, secretKey, err := getCredentials()
-		if err != nil {
-			return err
-		}
-
 		if dryRunFlag {
 			printStatus("[DRY RUN] Would delete user: id=%s\n", deleteUserIDFlag)
 			return nil
@@ -228,12 +199,9 @@ var deleteUserCmd = &cobra.Command{
 			return nil
 		}
 
-
-		client := lib.NewClient(accessKey, secretKey)
-
 		printStatus("Deleting user: %s\n", deleteUserIDFlag)
 
-		err = client.DeleteUser(cmd.Context(), deleteUserIDFlag)
+		err = dciClient.DeleteUser(cmd.Context(), deleteUserIDFlag)
 		if err != nil {
 			return fmt.Errorf("failed to delete user: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Added PersistentPreRunE on rootCmd that handles getCredentials() + lib.NewClient() once for all API commands
- Config subcommands are automatically skipped (no credentials needed)
- Removed 48 duplicated credential/client blocks across 12 cmd files (-285 net lines)
- Moved getCredentials() from cmd/get.go to cmd/root.go alongside other root utilities
- Updated credential-missing tests to work with the centralized pattern

Fixes #195