### PR TITLE
fix: bump Go toolchain to 1.26.7 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,14 @@ module github.com/sebrandon1/go-dci
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -28,6 +29,5 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sebrandon1/go-dci
 
 go 1.26
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=


### PR DESCRIPTION
## Summary

- Bumps `toolchain` in `go.mod` from `go1.26.5` to `go1.26.6`
- Fixes the failing **Security Scan** CI check on all open PRs
- Resolves 4 vulnerabilities reported by `govulncheck` — all in the Go standard library, all fixed in 1.26.6:
  - **GO-2026-3747** — `crypto/tls`
  - **GO-2026-3687** — `net/http`
  - **GO-2026-5972** — `encoding/asn1`
  - **GO-2026-5026** — `golang.org/x/net/idna` (via `net/http`)

## Test plan

- [ ] Security Scan passes with `govulncheck` finding no standard library vulnerabilities
- [ ] Run Linters passes
- [ ] Run Tests passes