### PR TITLE
feat: add Long descriptions and Example fields to all Cobra commands

### DIFF
--- a/cmd/componentsCmd.go
+++ b/cmd/componentsCmd.go
@@ -27,6 +27,9 @@ var (
 var getComponentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Get a specific component by ID",
+	Long:  `Retrieve detailed information about a single DCI component by its UUID.`,
+	Example: `  dci component --id <component-uuid>
+  dci component --id <component-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getComponentIDFlag, "component"); err != nil {
 			return err
@@ -53,6 +56,10 @@ var getComponentCmd = &cobra.Command{
 var createComponentCmd = &cobra.Command{
 	Use:   "create-component",
 	Short: "Create a new component in DCI",
+	Long: `Create a new versioned component in DCI associated with a topic.
+The component type must exist in DCI before creation.`,
+	Example: `  dci create-component --name "OCP 4.17.3" --type ocp --topic-id <topic-uuid> --version 4.17.3
+  dci create-component --name "OCP 4.17.3" --type ocp --topic-id <topic-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if dryRunFlag {
@@ -81,6 +88,10 @@ var createComponentCmd = &cobra.Command{
 var updateComponentCmd = &cobra.Command{
 	Use:   "update-component",
 	Short: "Update an existing component in DCI",
+	Long:  `Update mutable fields (name, state, version, tags) of a DCI component by UUID.`,
+	Example: `  dci update-component --id <component-uuid> --state active
+  dci update-component --id <component-uuid> --version 4.17.4 --tags "ga,stable"
+  dci update-component --id <component-uuid> --name "OCP 4.17.4" --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateComponentIDFlag, "component"); err != nil {
 			return err
@@ -131,6 +142,11 @@ var updateComponentCmd = &cobra.Command{
 var deleteComponentCmd = &cobra.Command{
 	Use:   "delete-component",
 	Short: "Delete a component from DCI",
+	Long: `Permanently delete a DCI component by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-component --id <component-uuid>
+  dci delete-component --id <component-uuid> --yes
+  dci delete-component --id <component-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteComponentIDFlag, "component"); err != nil {
 			return err

--- a/cmd/componenttypesCmd.go
+++ b/cmd/componenttypesCmd.go
@@ -21,6 +21,9 @@ var (
 var getComponentTypeCmd = &cobra.Command{
 	Use:   "componenttype",
 	Short: "Get a specific component type by ID",
+	Long:  `Retrieve detailed information about a single DCI component type by its UUID.`,
+	Example: `  dci componenttype --id <componenttype-uuid>
+  dci componenttype --id <componenttype-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getComponentTypeIDFlag, "component type"); err != nil {
 			return err
@@ -47,6 +50,9 @@ var getComponentTypeCmd = &cobra.Command{
 var createComponentTypeCmd = &cobra.Command{
 	Use:   "create-componenttype",
 	Short: "Create a new component type in DCI",
+	Long:  `Create a new component type classifier in DCI (e.g., "ocp", "rhcos", "certsuite").`,
+	Example: `  dci create-componenttype --name ocp
+  dci create-componenttype --name certsuite --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if dryRunFlag {
@@ -75,6 +81,9 @@ var createComponentTypeCmd = &cobra.Command{
 var updateComponentTypeCmd = &cobra.Command{
 	Use:   "update-componenttype",
 	Short: "Update an existing component type in DCI",
+	Long:  `Update the name or state of a DCI component type by its UUID.`,
+	Example: `  dci update-componenttype --id <componenttype-uuid> --name ocp-stable
+  dci update-componenttype --id <componenttype-uuid> --state inactive --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateComponentTypeIDFlag, "component type"); err != nil {
 			return err
@@ -115,6 +124,10 @@ var updateComponentTypeCmd = &cobra.Command{
 var deleteComponentTypeCmd = &cobra.Command{
 	Use:   "delete-componenttype",
 	Short: "Delete a component type from DCI",
+	Long: `Permanently delete a DCI component type by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-componenttype --id <componenttype-uuid>
+  dci delete-componenttype --id <componenttype-uuid> --yes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteComponentTypeIDFlag, "component type"); err != nil {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -57,11 +57,21 @@ func maskCredential(value string) string {
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Set or get configuration values",
+	Long: `Manage go-dci configuration (DCI API credentials). Config is stored at
+$XDG_CONFIG_HOME/go-dci/config.yaml (default: ~/.config/go-dci/config.yaml).
+
+Credentials can also be provided via environment variables:
+  GO_DCI_ACCESSKEY and GO_DCI_SECRETKEY`,
+	Example: `  dci config set --accesskey <key> --secretkey <secret>
+  dci config view
+  dci config unset --key accesskey`,
 }
 
 var setCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set a key value pair to the configuration",
+	Long:  `Store DCI API credentials in the go-dci config file.`,
+	Example: `  dci config set --accesskey myaccesskey --secretkey mysecretkey`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		accesskey, _ := cmd.Flags().GetString(configKeyAccessKey)
 		secretkey, _ := cmd.Flags().GetString(configKeySecretKey)
@@ -87,6 +97,9 @@ var setCmd = &cobra.Command{
 var unsetCmd = &cobra.Command{
 	Use:   "unset",
 	Short: "Unset a key value pair from the configuration",
+	Long:  `Remove a configuration key (e.g., accesskey or secretkey) from the go-dci config file.`,
+	Example: `  dci config unset --key accesskey
+  dci config unset --key secretkey`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, _ := cmd.Flags().GetString("key")
 
@@ -108,6 +121,8 @@ var unsetCmd = &cobra.Command{
 var viewCmd = &cobra.Command{
 	Use:   "view",
 	Short: "View the configuration",
+	Long:  `Display the current go-dci configuration. Credential values are masked, showing only the last 4 characters.`,
+	Example: `  dci config view`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Configuration:")
 

--- a/cmd/filesCmd.go
+++ b/cmd/filesCmd.go
@@ -18,6 +18,17 @@ var (
 var getFileCmd = &cobra.Command{
 	Use:   "file",
 	Short: "Download a file by ID",
+	Long: `Download a file from DCI by its UUID. Without --output-path the command prints
+file metadata (ID, content type, size). Use --output-path to write the content
+to disk.`,
+	Example: `  # Print file metadata
+  dci file --id <file-uuid>
+
+  # Save file to disk
+  dci file --id <file-uuid> --output-path /tmp/results.xml
+
+  # Metadata as JSON
+  dci file --id <file-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getFileIDFlag, "file"); err != nil {
 			return err
@@ -58,6 +69,10 @@ var getFileCmd = &cobra.Command{
 var deleteFileCmd = &cobra.Command{
 	Use:   "delete-file",
 	Short: "Delete a file from DCI",
+	Long: `Permanently delete a DCI file by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-file --id <file-uuid>
+  dci delete-file --id <file-uuid> --yes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteFileIDFlag, "file"); err != nil {
 			return err

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -31,6 +31,16 @@ var (
 var getTopicsCmd = &cobra.Command{
 	Use:   "topics",
 	Short: "Get all topics from DCI, optionally filtered by name",
+	Long: `Retrieve all topics from DCI. Topics group components and jobs under a named
+release or product version (e.g., OCP-4.17). Use --name to filter by substring match.`,
+	Example: `  # List all topics
+  dci topics
+
+  # Filter topics by name
+  dci topics --name OCP-4.17
+
+  # Output as JSON for scripting
+  dci topics -o json | jq '.topics[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if nameFilter != "" {
@@ -63,6 +73,16 @@ var getTopicsCmd = &cobra.Command{
 var getComponentTypesCmd = &cobra.Command{
 	Use:   "componenttypes",
 	Short: "Get all component types from DCI, optionally filtered by name",
+	Long: `Retrieve all component types from DCI. Component types classify components
+within a topic (e.g., "ocp", "rhcos"). Use --name to filter by substring match.`,
+	Example: `  # List all component types
+  dci componenttypes
+
+  # Filter by name
+  dci componenttypes --name ocp
+
+  # Output as JSON
+  dci componenttypes -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if nameFilter != "" {
@@ -95,6 +115,14 @@ var getComponentTypesCmd = &cobra.Command{
 var getIdentityCmd = &cobra.Command{
 	Use:   "identity",
 	Short: "Verify authentication and display current identity information",
+	Long: `Verify that the configured credentials are valid and display the authenticated
+identity's details (name, type, team, state). Useful for confirming credentials
+before running other commands.`,
+	Example: `  # Check current identity
+  dci identity
+
+  # Output identity as JSON
+  dci identity -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		identity, err := dciClient.GetIdentity(cmd.Context())
@@ -115,6 +143,17 @@ var getIdentityCmd = &cobra.Command{
 var getOcpCountCmd = &cobra.Command{
 	Use:   "ocpcount",
 	Short: "Get the count of jobs for each OCP version",
+	Long: `Summarize certsuite job counts grouped by OCP version for a given time window.
+Looks for jobs containing "cnf-certification-test" or "certsuite" components and
+extracts the OpenShift version from co-located components.
+
+The OCP versions tracked can be overridden with the OCP_VERSIONS_TO_TRACK
+environment variable (comma-separated, e.g. "4.16,4.17,4.18").`,
+	Example: `  # Count certsuite jobs from the last 30 days
+  dci ocpcount --age 30
+
+  # Output as JSON for scripting
+  dci ocpcount --age 7 -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printStatus("Getting all jobs from DCI that are %s days old\n", ageInDays)
 
@@ -143,6 +182,20 @@ var getOcpCountCmd = &cobra.Command{
 var getComponentsCmd = &cobra.Command{
 	Use:   "components",
 	Short: "Get all components, optionally filtered by topic, type, or name",
+	Long: `Retrieve components from DCI. Components represent versioned artifacts
+(e.g., OCP 4.17.3, RHCOS 417.94) associated with a topic. Filters can be
+combined to narrow results by topic ID, component type, or name substring.`,
+	Example: `  # List all components
+  dci components
+
+  # Filter by topic ID
+  dci components --topic <topic-uuid>
+
+  # Filter by type and name
+  dci components --type ocp --name 4.17
+
+  # Output as JSON
+  dci components --topic <topic-uuid> -o json | jq '.components[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		var statusMsg string
@@ -185,7 +238,21 @@ var getComponentsCmd = &cobra.Command{
 
 var getJobsCmd = &cobra.Command{
 	Use:   "jobs",
-	Short: "Get all jobs with a specific age in days or date range",
+	Short: "Get all certsuite jobs with a specific age in days or date range",
+	Long: `Retrieve certsuite jobs from DCI filtered by a time window. Jobs are filtered
+to those containing "cnf-certification-test" or "certsuite" components and the
+certsuite version is extracted from the component name.
+
+Use --age for a rolling window from today, or --start-date/--end-date for a
+specific range. The two approaches are mutually exclusive.`,
+	Example: `  # Get certsuite jobs from the last 7 days
+  dci jobs --age 7
+
+  # Get jobs in a specific date range
+  dci jobs --start-date 2026-01-01 --end-date 2026-01-31
+
+  # Output as JSON
+  dci jobs --age 30 -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if ageInDays != "" && (startDate != "" || endDate != "") {
 			return fmt.Errorf("--age and --start-date/--end-date are mutually exclusive")

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -23,6 +23,9 @@ var (
 var getJobCmd = &cobra.Command{
 	Use:   "job",
 	Short: "Get a specific job by ID",
+	Long:  `Retrieve detailed information about a single DCI job by its UUID.`,
+	Example: `  dci job --id <job-uuid>
+  dci job --id <job-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getJobIDFlag, "job"); err != nil {
 			return err
@@ -49,6 +52,10 @@ var getJobCmd = &cobra.Command{
 var updateJobCmd = &cobra.Command{
 	Use:   "update-job",
 	Short: "Update an existing job in DCI",
+	Long:  `Update a DCI job's comment and/or tags by its UUID.`,
+	Example: `  dci update-job --id <job-uuid> --comment "nightly run"
+  dci update-job --id <job-uuid> --tags "ocp,certsuite,4.17"
+  dci update-job --id <job-uuid> --comment "retry" --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateJobIDFlag, "job"); err != nil {
 			return err
@@ -93,6 +100,11 @@ var updateJobCmd = &cobra.Command{
 var deleteJobCmd = &cobra.Command{
 	Use:   "delete-job",
 	Short: "Delete a job from DCI",
+	Long: `Permanently delete a DCI job by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-job --id <job-uuid>
+  dci delete-job --id <job-uuid> --yes
+  dci delete-job --id <job-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteJobIDFlag, "job"); err != nil {
 			return err
@@ -135,6 +147,12 @@ var deleteJobCmd = &cobra.Command{
 var scheduleJobCmd = &cobra.Command{
 	Use:   "schedule-job",
 	Short: "Schedule a job with auto-selected components",
+	Long: `Schedule a new DCI job for a topic. DCI automatically selects the latest
+available components for the topic. Use create-job to specify component IDs
+explicitly.`,
+	Example: `  dci schedule-job --topic-id <topic-uuid>
+  dci schedule-job --topic-id <topic-uuid> -o json
+  dci schedule-job --topic-id <topic-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(scheduleJobTopicID, "topic"); err != nil {
 			return err
@@ -167,6 +185,9 @@ var scheduleJobCmd = &cobra.Command{
 var getJobFilesCmd = &cobra.Command{
 	Use:   "job-files",
 	Short: "Get all files for a specific job",
+	Long:  `List all files (e.g., test results, logs) attached to a DCI job by its UUID.`,
+	Example: `  dci job-files --id <job-uuid>
+  dci job-files --id <job-uuid> -o json | jq '.files[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(jobFilesIDFlag, "job"); err != nil {
 			return err

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -16,6 +16,17 @@ var (
 var getJobStatesCmd = &cobra.Command{
 	Use:   "jobstates",
 	Short: "Get job states, optionally filtered by job ID",
+	Long: `Retrieve job state transitions from DCI. Job states track the lifecycle of a job
+(e.g., new → pre-run → running → success/failure). Filter by --job-id to see
+only the states for a specific job.`,
+	Example: `  # List all job states
+  dci jobstates
+
+  # Filter by job
+  dci jobstates --job-id <job-uuid>
+
+  # Output as JSON
+  dci jobstates --job-id <job-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if getJobStatesJobIDFlag != "" {
 			if err := validateResourceID(getJobStatesJobIDFlag, "job"); err != nil {

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -25,6 +25,11 @@ var (
 var createJobCmd = &cobra.Command{
 	Use:   "create-job",
 	Short: "Create a new job in DCI",
+	Long: `Create a new DCI job for a topic with explicit component IDs. Use schedule-job
+to let DCI auto-select the latest components for a topic.`,
+	Example: `  dci create-job --topic-id <topic-uuid> --components <comp-uuid1>,<comp-uuid2>
+  dci create-job --topic-id <topic-uuid> --comment "nightly regression"
+  dci create-job --topic-id <topic-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		// Parse component IDs if provided
@@ -61,6 +66,14 @@ var createJobCmd = &cobra.Command{
 var updateJobStateCmd = &cobra.Command{
 	Use:   "update-job-state",
 	Short: "Update the state of a job (pre-run, running, success, failure, etc.)",
+	Long: `Transition a DCI job to a new lifecycle state. Valid states are:
+  new, pre-run, running, post-run, success, failure, killed, error
+
+An optional comment can be attached to document the reason for the transition.`,
+	Example: `  dci update-job-state --job-id <job-uuid> --status running
+  dci update-job-state --job-id <job-uuid> --status success
+  dci update-job-state --job-id <job-uuid> --status failure --comment "test timeout"
+  dci update-job-state --job-id <job-uuid> --status running --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateJobStateJobID, "job"); err != nil {
 			return err
@@ -104,6 +117,16 @@ var updateJobStateCmd = &cobra.Command{
 var uploadFileCmd = &cobra.Command{
 	Use:   "upload-file",
 	Short: "Upload a file (e.g., test results) to a job in DCI",
+	Long: `Upload a file to a DCI job. Defaults to MIME type application/junit for JUnit
+XML test results. Specify --mime to override for other file types (e.g.,
+application/xml, text/plain).`,
+	Example: `  # Upload JUnit XML results (default mime type)
+  dci upload-file --job-id <job-uuid> --file ./results.xml
+
+  # Upload with custom MIME type
+  dci upload-file --job-id <job-uuid> --file ./report.html --mime text/html
+
+  dci upload-file --job-id <job-uuid> --file ./results.xml --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Default mime type for test results
 		if uploadFileMimeType == "" {

--- a/cmd/productsCmd.go
+++ b/cmd/productsCmd.go
@@ -16,6 +16,10 @@ var (
 var getProductsCmd = &cobra.Command{
 	Use:   "products",
 	Short: "Get all products from DCI",
+	Long: `Retrieve all products registered in DCI. Products are top-level groupings
+(e.g., OpenShift) under which topics and components are organized.`,
+	Example: `  dci products
+  dci products -o json | jq '.products[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		printStatus("Getting products...")
@@ -38,6 +42,9 @@ var getProductsCmd = &cobra.Command{
 var getProductCmd = &cobra.Command{
 	Use:   "product",
 	Short: "Get a specific product by ID",
+	Long:  `Retrieve detailed information about a single DCI product by its UUID.`,
+	Example: `  dci product --id <product-uuid>
+  dci product --id <product-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getProductIDFlag, "product"); err != nil {
 			return err

--- a/cmd/remotecisCmd.go
+++ b/cmd/remotecisCmd.go
@@ -22,6 +22,11 @@ var (
 var getRemoteCIsCmd = &cobra.Command{
 	Use:   "remotecis",
 	Short: "Get all remote CIs from DCI",
+	Long: `Retrieve all remote CI agents registered in DCI. Remote CIs represent the
+CI systems (e.g., Jenkins agents, test runners) that execute DCI jobs.
+API credentials are redacted from JSON output.`,
+	Example: `  dci remotecis
+  dci remotecis -o json | jq '.remotecis[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		printStatus("Getting remote CIs...")
@@ -44,6 +49,9 @@ var getRemoteCIsCmd = &cobra.Command{
 var getRemoteCICmd = &cobra.Command{
 	Use:   "remoteci",
 	Short: "Get a specific remote CI by ID",
+	Long:  `Retrieve detailed information about a single DCI remote CI by its UUID. API credentials are redacted.`,
+	Example: `  dci remoteci --id <remoteci-uuid>
+  dci remoteci --id <remoteci-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getRemoteCIsCmd_IDFlag, "remote CI"); err != nil {
 			return err
@@ -70,6 +78,9 @@ var getRemoteCICmd = &cobra.Command{
 var createRemoteCICmd = &cobra.Command{
 	Use:   "create-remoteci",
 	Short: "Create a new remote CI in DCI",
+	Long:  `Register a new remote CI agent in DCI, associated with a team.`,
+	Example: `  dci create-remoteci --name my-lab-runner --team-id <team-uuid>
+  dci create-remoteci --name my-lab-runner --team-id <team-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if dryRunFlag {
@@ -98,6 +109,9 @@ var createRemoteCICmd = &cobra.Command{
 var updateRemoteCICmd = &cobra.Command{
 	Use:   "update-remoteci",
 	Short: "Update an existing remote CI in DCI",
+	Long:  `Update the name or state of a DCI remote CI by its UUID.`,
+	Example: `  dci update-remoteci --id <remoteci-uuid> --name new-lab-name
+  dci update-remoteci --id <remoteci-uuid> --state inactive --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateRemoteCIIDFlag, "remote CI"); err != nil {
 			return err
@@ -138,6 +152,10 @@ var updateRemoteCICmd = &cobra.Command{
 var deleteRemoteCICmd = &cobra.Command{
 	Use:   "delete-remoteci",
 	Short: "Delete a remote CI from DCI",
+	Long: `Permanently delete a DCI remote CI by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-remoteci --id <remoteci-uuid>
+  dci delete-remoteci --id <remoteci-uuid> --yes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteRemoteCIIDFlag, "remote CI"); err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,17 @@ import (
 var Version = "dev"
 
 var rootCmd = &cobra.Command{
-	Use:     "dci",
-	Short:   "CLI and library for the Red Hat Distributed CI API",
+	Use:   "dci",
+	Short: "CLI and library for the Red Hat Distributed CI API",
+	Long: `go-dci is a command-line tool for interacting with the Red Hat Distributed CI
+(DCI) API. It supports full CRUD operations on topics, jobs, components,
+component types, teams, users, remote CIs, products, files, and job states.
+
+Configure credentials before first use:
+  dci config set --accesskey <key> --secretkey <secret>
+
+Credentials can also be provided via environment variables:
+  GO_DCI_ACCESSKEY and GO_DCI_SECRETKEY`,
 	Version: Version,
 }
 

--- a/cmd/teamsCmd.go
+++ b/cmd/teamsCmd.go
@@ -22,6 +22,11 @@ var (
 var getTeamsCmd = &cobra.Command{
 	Use:   "teams",
 	Short: "Get all teams from DCI, optionally filtered by name",
+	Long: `Retrieve all teams from DCI. Teams group users and remote CIs and control
+access to topics and products. Use --name to filter by substring match.`,
+	Example: `  dci teams
+  dci teams --name acme
+  dci teams -o json | jq '.teams[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if teamsNameFilter != "" {
@@ -48,6 +53,9 @@ var getTeamsCmd = &cobra.Command{
 var getTeamCmd = &cobra.Command{
 	Use:   "team",
 	Short: "Get a specific team by ID",
+	Long:  `Retrieve detailed information about a single DCI team by its UUID.`,
+	Example: `  dci team --id <team-uuid>
+  dci team --id <team-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getTeamIDFlag, "team"); err != nil {
 			return err
@@ -74,6 +82,9 @@ var getTeamCmd = &cobra.Command{
 var createTeamCmd = &cobra.Command{
 	Use:   "create-team",
 	Short: "Create a new team in DCI",
+	Long:  `Create a new team in DCI. Teams are used to control access to topics and products.`,
+	Example: `  dci create-team --name "acme-labs"
+  dci create-team --name "acme-labs" --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if dryRunFlag {
@@ -102,6 +113,9 @@ var createTeamCmd = &cobra.Command{
 var updateTeamCmd = &cobra.Command{
 	Use:   "update-team",
 	Short: "Update an existing team in DCI",
+	Long:  `Update the name or state of a DCI team by its UUID.`,
+	Example: `  dci update-team --id <team-uuid> --name "acme-labs-v2"
+  dci update-team --id <team-uuid> --state inactive --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateTeamIDFlag, "team"); err != nil {
 			return err
@@ -142,6 +156,10 @@ var updateTeamCmd = &cobra.Command{
 var deleteTeamCmd = &cobra.Command{
 	Use:   "delete-team",
 	Short: "Delete a team from DCI",
+	Long: `Permanently delete a DCI team by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-team --id <team-uuid>
+  dci delete-team --id <team-uuid> --yes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteTeamIDFlag, "team"); err != nil {
 			return err

--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -24,6 +24,9 @@ var (
 var getTopicCmd = &cobra.Command{
 	Use:   "topic",
 	Short: "Get a specific topic by ID",
+	Long:  `Retrieve detailed information about a single DCI topic by its UUID.`,
+	Example: `  dci topic --id <topic-uuid>
+  dci topic --id <topic-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getTopicIDFlag, "topic"); err != nil {
 			return err
@@ -50,6 +53,11 @@ var getTopicCmd = &cobra.Command{
 var createTopicCmd = &cobra.Command{
 	Use:   "create-topic",
 	Short: "Create a new topic in DCI",
+	Long: `Create a new topic in DCI associated with a product. Optionally specify
+component types that are valid for components under this topic.`,
+	Example: `  dci create-topic --name OCP-4.18 --product-id <product-uuid>
+  dci create-topic --name OCP-4.18 --product-id <product-uuid> --component-types ocp,rhcos
+  dci create-topic --name OCP-4.18 --product-id <product-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		// Parse component types if provided
@@ -87,6 +95,9 @@ var createTopicCmd = &cobra.Command{
 var updateTopicCmd = &cobra.Command{
 	Use:   "update-topic",
 	Short: "Update an existing topic in DCI",
+	Long:  `Update mutable fields of a DCI topic identified by its UUID.`,
+	Example: `  dci update-topic --id <topic-uuid> --name OCP-4.18-GA
+  dci update-topic --id <topic-uuid> --name OCP-4.18-GA --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateTopicIDFlag, "topic"); err != nil {
 			return err
@@ -124,6 +135,11 @@ var updateTopicCmd = &cobra.Command{
 var deleteTopicCmd = &cobra.Command{
 	Use:   "delete-topic",
 	Short: "Delete a topic from DCI",
+	Long: `Permanently delete a DCI topic by its UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-topic --id <topic-uuid>
+  dci delete-topic --id <topic-uuid> --yes
+  dci delete-topic --id <topic-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteTopicIDFlag, "topic"); err != nil {
 			return err
@@ -166,6 +182,9 @@ var deleteTopicCmd = &cobra.Command{
 var getTopicComponentsCmd = &cobra.Command{
 	Use:   "topic-components",
 	Short: "Get all components for a specific topic",
+	Long:  `Retrieve all components associated with a DCI topic by its UUID.`,
+	Example: `  dci topic-components --id <topic-uuid>
+  dci topic-components --id <topic-uuid> -o json | jq '.components[].name'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(topicComponentsIDFlag, "topic"); err != nil {
 			return err

--- a/cmd/usersCmd.go
+++ b/cmd/usersCmd.go
@@ -30,6 +30,10 @@ var (
 var getUsersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Get all users from DCI, optionally filtered by name",
+	Long:  `Retrieve all users registered in DCI. Use --name to filter by username substring match.`,
+	Example: `  dci users
+  dci users --name alice
+  dci users -o json | jq '.users[].email'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if usersNameFilter != "" {
@@ -56,6 +60,9 @@ var getUsersCmd = &cobra.Command{
 var getUserCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Get a specific user by ID",
+	Long:  `Retrieve detailed information about a single DCI user by their UUID.`,
+	Example: `  dci user --id <user-uuid>
+  dci user --id <user-uuid> -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(getUserIDFlag, "user"); err != nil {
 			return err
@@ -82,6 +89,15 @@ var getUserCmd = &cobra.Command{
 var createUserCmd = &cobra.Command{
 	Use:   "create-user",
 	Short: "Create a new user in DCI",
+	Long: `Create a new user in DCI. A password is required: provide it with --password or
+omit it to be prompted interactively (recommended to avoid shell history exposure).`,
+	Example: `  # Interactive password prompt (recommended)
+  dci create-user --name alice --email alice@example.com --team-id <team-uuid>
+
+  # Explicit password (avoid in scripts — use env var or prompt instead)
+  dci create-user --name alice --email alice@example.com --team-id <team-uuid> --password s3cr3t
+
+  dci create-user --name alice --email alice@example.com --team-id <team-uuid> --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		password := createUserPasswordFlag
 		if password == "" {
@@ -133,6 +149,9 @@ var createUserCmd = &cobra.Command{
 var updateUserCmd = &cobra.Command{
 	Use:   "update-user",
 	Short: "Update an existing user in DCI",
+	Long:  `Update mutable fields (name, email, fullname, state) of a DCI user by UUID.`,
+	Example: `  dci update-user --id <user-uuid> --email new@example.com
+  dci update-user --id <user-uuid> --state inactive --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(updateUserIDFlag, "user"); err != nil {
 			return err
@@ -179,6 +198,10 @@ var updateUserCmd = &cobra.Command{
 var deleteUserCmd = &cobra.Command{
 	Use:   "delete-user",
 	Short: "Delete a user from DCI",
+	Long: `Permanently delete a DCI user by their UUID. Prompts for confirmation
+unless --yes is set or output is JSON (automation mode).`,
+	Example: `  dci delete-user --id <user-uuid>
+  dci delete-user --id <user-uuid> --yes`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateResourceID(deleteUserIDFlag, "user"); err != nil {
 			return err


### PR DESCRIPTION
Closes #187

## Summary
- Added `Long` and `Example` fields to all 34 Cobra commands across 13 files
- Every `dci help <command>` now shows a detailed description of what the command does and concrete usage examples
- No behavioral changes — documentation only

## Changes
- `cmd/root.go` — root command long description with credential setup instructions
- `cmd/get.go` — topics, componenttypes, identity, ocpcount, components, jobs
- `cmd/topics.go` — topic, create-topic, update-topic, delete-topic, topic-components
- `cmd/jobs.go` — job, update-job, delete-job, schedule-job, job-files
- `cmd/componentsCmd.go` — component, create-component, update-component, delete-component
- `cmd/componenttypesCmd.go` — componenttype, create-componenttype, update-componenttype, delete-componenttype
- `cmd/remotecisCmd.go` — remotecis, remoteci, create-remoteci, update-remoteci, delete-remoteci
- `cmd/teamsCmd.go` — teams, team, create-team, update-team, delete-team
- `cmd/usersCmd.go` — users, user, create-user, update-user, delete-user
- `cmd/productsCmd.go` — products, product
- `cmd/filesCmd.go` — file, delete-file
- `cmd/jobstatesCmd.go` — jobstates
- `cmd/post.go` — create-job, update-job-state, upload-file
- `cmd/config.go` — config, set, unset, view

## Test Plan
- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `dci help topics` and `dci help update-job-state` verified to show Long + Examples