### PR TITLE
fix: add consistent total field to all list command JSON output

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -391,7 +391,10 @@ func runCertsuiteJobsOutput(jobsResponses []lib.JobsResponse, startRun time.Time
 		printStatus("Total DCI Jobs: %d", totalJobsCtr)
 		printStatus("Total go-dci runtime: %v", time.Since(startRun))
 	} else {
-		jsonOutputBytes, err := json.Marshal(jsonOutput)
+		jsonOutputBytes, err := json.Marshal(map[string]any{
+			"jobs":  jsonOutput.Jobs,
+			"total": len(jsonOutput.Jobs),
+		})
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON output: %w", err)
 		}
@@ -519,13 +522,10 @@ func printComponentsJSON(componentsResponses []lib.ComponentsResponse) error {
 		allComponents = append(allComponents, cr.Components...)
 	}
 
-	output := struct {
-		Components []lib.Components `json:"components"`
-	}{
-		Components: allComponents,
-	}
-
-	jsonBytes, err := json.Marshal(output)
+	jsonBytes, err := json.Marshal(map[string]any{
+		"components": allComponents,
+		"total":      len(allComponents),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
@@ -580,13 +580,10 @@ func printComponentTypesJSON(componentTypesResponses []lib.ComponentTypesRespons
 		allComponentTypes = append(allComponentTypes, ctr.ComponentTypes...)
 	}
 
-	output := struct {
-		ComponentTypes []lib.ComponentType `json:"componenttypes"`
-	}{
-		ComponentTypes: allComponentTypes,
-	}
-
-	jsonBytes, err := json.Marshal(output)
+	jsonBytes, err := json.Marshal(map[string]any{
+		"componenttypes": allComponentTypes,
+		"total":          len(allComponentTypes),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
@@ -632,13 +629,10 @@ func printTopicsJSON(topicsResponses []lib.TopicsResponse) error {
 		}
 	}
 
-	output := struct {
-		Topics []Topic `json:"topics"`
-	}{
-		Topics: allTopics,
-	}
-
-	jsonBytes, err := json.Marshal(output)
+	jsonBytes, err := json.Marshal(map[string]any{
+		"topics": allTopics,
+		"total":  len(allTopics),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}

--- a/cmd/jobstatesCmd.go
+++ b/cmd/jobstatesCmd.go
@@ -81,13 +81,10 @@ func printJobStatesJSON(responses []lib.JobStatesResponse) error {
 		allJobStates = append(allJobStates, response.JobStates...)
 	}
 
-	output := struct {
-		JobStates []lib.JobStateEntry `json:"jobstates"`
-	}{
-		JobStates: allJobStates,
-	}
-
-	jsonBytes, err := json.Marshal(output)
+	jsonBytes, err := json.Marshal(map[string]any{
+		"jobstates": allJobStates,
+		"total":     len(allJobStates),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}


### PR DESCRIPTION
Closes #198

## Summary
- `topics`, `componenttypes`, `components`, `jobstates`, and certsuite `jobs` JSON output now all include a `"total": N` field alongside the items array
- This matches the existing envelope already used by `remotecis`, `teams`, `users`, and `products`
- No breaking changes to key names — only additive (new `total` field)

## Before / After

```
# Before
dci topics -o json    → {"topics": [...]}
dci componenttypes -o json → {"componenttypes": [...]}
dci components -o json → {"components": [...]}
dci jobstates -o json → {"jobstates": [...]}

# After (consistent with remotecis/teams/users/products)
dci topics -o json    → {"topics": [...], "total": 5}
dci componenttypes -o json → {"componenttypes": [...], "total": 3}
dci components -o json → {"components": [...], "total": 12}
dci jobstates -o json → {"jobstates": [...], "total": 7}
```

## Changes
- `cmd/get.go`: `printTopicsJSON`, `printComponentTypesJSON`, `printComponentsJSON`, certsuite jobs JSON branch
- `cmd/jobstatesCmd.go`: `printJobStatesJSON`